### PR TITLE
fix(project): Version bump to higher than all previous ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-auth",
-  "version": "0.1.2",
+  "version": "0.12.0",
   "description": "Plugin for social media authentication and local authentication together with other authentication utilities.",
   "main": "dist/system/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "aurelia-tools": "^0.1.3",
     "babel-eslint": "^4.1.6",
     "browser-sync": "^1.8.1",
-    "conventional-changelog": "0.0.11",
+    "conventional-changelog": "0.0.17",
     "del": "^1.1.0",
     "gulp": "^3.8.10",
     "gulp-babel": "^5.1.0",


### PR DESCRIPTION
There already was a tag v0.11.5 from the original version. thus jspm install github:spoonx/aurelia-auth installs v.0.11.5 and not the newer but lower 0.1.2
