### PR TITLE
Updated build d.ts file generation to exclude imports and prevent exporting 'authUtils.js'.

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -12,7 +12,8 @@ module.exports = {
   source: appRoot + '**/*.js',
   tsSource: [
     appRoot + '**/*.js',          // list files to parse for d.ts
-   '!' + appRoot + entryFileName  // exclude entry file
+   '!' + appRoot + entryFileName, // exclude entry file
+   '!**/authUtils.js'  			  // exclude utility functions
   ],
   html: appRoot + '**/*.html',
   style: 'styles/**/*.css',

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -15,21 +15,19 @@ var vinylPaths = require('vinyl-paths');
 // merged output file name. a folder of paths.packageName is temporarly created in build-dts
 var jsName = paths.packageName + '.js';
 
-
 gulp.task('build-dts', function() {
   var importsToAdd = []; // stores extracted imports
 
   return gulp.src(paths.tsSource)
     .pipe(tools.sortFiles())
     .pipe(through2.obj(function(file, enc, callback) {  // extract all imports to importsToAdd
-      file.contents = new Buffer(tools.extractImports(file.contents.toString('utf8'), importsToAdd));
-      this.push(file);
+      if (file) {
+        file.contents = new Buffer(tools.extractImports(file.contents.toString('utf8'), importsToAdd));
+        this.push(file);
+      }
       return callback();
     }))
     .pipe(concat(jsName)) // concat all selected files to jsName (now without their imports)
-    .pipe(insert.transform(function(contents) { // re-add extracted imports on top
-      return tools.createImportBlock(importsToAdd) + contents;
-    }))
     .pipe(to5(assign({}, compilerOptions.dts()))); // compile to d.ts from file jsName. d.ts file is in folder paths.packageName
 });
 

--- a/dist/amd/aurelia-authentication.d.ts
+++ b/dist/amd/aurelia-authentication.d.ts
@@ -1,23 +1,7 @@
 declare module 'aurelia-authentication' {
-  import {
-    inject
-  } from 'aurelia-dependency-injection';
-  import {
-    HttpClient
-  } from 'aurelia-fetch-client';
-  import {
-    Config,
-    Rest
-  } from 'spoonx/aurelia-api';
-  import {
-    Redirect
-  } from 'aurelia-router';
   export class AuthFilterValueConverter {
     toView(routes: any, isAuthenticated: any): any;
   }
-  export {
-    authUtils
-  };
   export class BaseConfig {
     configure(incomingConfig: any): any;
     current: any;

--- a/dist/commonjs/aurelia-authentication.d.ts
+++ b/dist/commonjs/aurelia-authentication.d.ts
@@ -1,23 +1,7 @@
 declare module 'aurelia-authentication' {
-  import {
-    inject
-  } from 'aurelia-dependency-injection';
-  import {
-    HttpClient
-  } from 'aurelia-fetch-client';
-  import {
-    Config,
-    Rest
-  } from 'spoonx/aurelia-api';
-  import {
-    Redirect
-  } from 'aurelia-router';
   export class AuthFilterValueConverter {
     toView(routes: any, isAuthenticated: any): any;
   }
-  export {
-    authUtils
-  };
   export class BaseConfig {
     configure(incomingConfig: any): any;
     current: any;

--- a/dist/es2015/aurelia-authentication.d.ts
+++ b/dist/es2015/aurelia-authentication.d.ts
@@ -1,23 +1,7 @@
 declare module 'aurelia-authentication' {
-  import {
-    inject
-  } from 'aurelia-dependency-injection';
-  import {
-    HttpClient
-  } from 'aurelia-fetch-client';
-  import {
-    Config,
-    Rest
-  } from 'spoonx/aurelia-api';
-  import {
-    Redirect
-  } from 'aurelia-router';
   export class AuthFilterValueConverter {
     toView(routes: any, isAuthenticated: any): any;
   }
-  export {
-    authUtils
-  };
   export class BaseConfig {
     configure(incomingConfig: any): any;
     current: any;

--- a/dist/system/aurelia-authentication.d.ts
+++ b/dist/system/aurelia-authentication.d.ts
@@ -1,23 +1,7 @@
 declare module 'aurelia-authentication' {
-  import {
-    inject
-  } from 'aurelia-dependency-injection';
-  import {
-    HttpClient
-  } from 'aurelia-fetch-client';
-  import {
-    Config,
-    Rest
-  } from 'spoonx/aurelia-api';
-  import {
-    Redirect
-  } from 'aurelia-router';
   export class AuthFilterValueConverter {
     toView(routes: any, isAuthenticated: any): any;
   }
-  export {
-    authUtils
-  };
   export class BaseConfig {
     configure(incomingConfig: any): any;
     current: any;


### PR DESCRIPTION
This update will exclude all imports in the d.ts file generation. It will also prevent the generation of export {authUtils} which TS doesn't seem to like having.
