### PR TITLE
refactor(baseConfig): standardise access token option names (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,21 +300,6 @@ unlinkUrl: '/auth/unlink/',
 // The HTTP method used for 'unlink' requests (Options: 'get' or 'post')
 unlinkMethod: 'get',
 
-// Refresh Token Options
-// =====================
-
-// Option to turn refresh tokens On/Off
-useRefreshToken: false,
-// The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
-autoUpdateToken: true,
-// This allows the refresh token to be a further object deeper `{ "responseTokenProp": { "refreshTokenRoot" : { "tokenName" : '...' } } }`
-refreshTokenRoot: false,
-// This is the property from which to get the token `{ "responseTokenProp": { "refreshTokenName" : '...' } }`
-refreshTokenName: 'refresh_token',
-// Prepended to the `refreshTokenName` when kept in storage (nothing to do with)
-refreshTokenPrefix: 'aurelia',
-// Oauth Client Id
-clientId: false,
 
 // Token Related options
 // =====================
@@ -325,6 +310,8 @@ authHeader: 'Authorization',
 authToken: 'Bearer',
 // The the property from which to get the authentication token after a successful login or signup
 responseTokenProp: 'access_token',
+// Prepended to the `tokenName` when kept in storage (nothing to do with access token responses)
+tokenPrefix: 'aurelia',
 
 // If the property defined by `responseTokenProp` is an object:
 // ------------------------------------------------------------
@@ -333,6 +320,29 @@ responseTokenProp: 'access_token',
 tokenName: 'token',
 // This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
 tokenRoot: false,
+
+
+// Refresh Token Options
+// =====================
+
+// Option to turn refresh tokens On/Off
+useRefreshToken: false,
+// The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
+autoUpdateToken: true,
+// The the property from which to get the refresh token after a successful token refresh
+refreshTokenProp: 'refresh_token',
+// Prepended to the `refreshTokenName` when kept in storage (nothing to do with refresh token responses)
+refreshTokenPrefix: 'aurelia',
+// Oauth Client Id
+clientId: false,
+
+// If the property defined by `refreshTokenProp` is an object:
+// ------------------------------------------------------------
+
+// This is the property from which to get the token `{ "refreshTokenProp": { "refreshTokenName" : '...' } }`
+refreshTokenName: 'token',
+// This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
+refreshTokenRoot: false,
 
 
 // Miscellaneous Options
@@ -347,8 +357,6 @@ withCredentials: true,
 platform: 'browser',
 // Determines the `window` property name upon which aurelia-authentication data is stored (Default: `window.localStorage`)
 storage: 'localStorage',
-// Prepended to the `tokenName` when kept in storage (nothing to do with)
-tokenPrefix: 'aurelia',
 
 
 // OAuth provider specific related configuration
@@ -367,7 +375,10 @@ providers: {
     display: 'popup',
     type: '2.0',
     /*clientId: '239531826023-ibk10mb9p7ull54j55a61og5lvnjrff6.apps.googleusercontent.com',*/
-    popupOptions: { width: 452, height: 633 }
+    popupOptions: {
+      width: 452,
+      height: 633
+    }
   },
   facebook: {
     name: 'facebook',
@@ -382,7 +393,10 @@ providers: {
     requiredUrlParams: ['nonce','display', 'scope'],
     display: 'popup',
     type: '2.0',
-    popupOptions: { width: 580, height: 400 }
+    popupOptions: {
+      width: 580,
+      height: 400
+    }
   },
   linkedin: {
     name: 'linkedin',
@@ -394,7 +408,10 @@ providers: {
     scopeDelimiter: ' ',
     state: 'STATE',
     type: '2.0',
-    popupOptions: { width: 527, height: 582 }
+    popupOptions: { 
+      width: 527,
+      height: 582
+    }
   },
   github: {
     name: 'github',
@@ -405,7 +422,10 @@ providers: {
     scope: ['user:email'],
     scopeDelimiter: ' ',
     type: '2.0',
-    popupOptions: { width: 1020, height: 618 }
+    popupOptions: {
+      width: 1020,
+      height: 618
+    }
   },
   yahoo: {
     name: 'yahoo',
@@ -415,14 +435,20 @@ providers: {
     scope: [],
     scopeDelimiter: ',',
     type: '2.0',
-    popupOptions: { width: 559, height: 519 }
+    popupOptions: {
+      width: 559,
+      height: 519
+    }
   },
   twitter: {
     name: 'twitter',
     url: '/auth/twitter',
     authorizationEndpoint: 'https://api.twitter.com/oauth/authenticate',
     type: '1.0',
-    popupOptions: { width: 495, height: 645 }
+    popupOptions: {
+      width: 495,
+      height: 645
+    }
   },
   live: {
     name: 'live',
@@ -434,7 +460,25 @@ providers: {
     requiredUrlParams: ['display', 'scope'],
     display: 'popup',
     type: '2.0',
-    popupOptions: { width: 500, height: 560 }
+    popupOptions: {
+      width: 500,
+      height: 560
+    }
+  },
+  instagram: {
+    name: 'instagram',
+    url: '/auth/instagram',
+    authorizationEndpoint: 'https://api.instagram.com/oauth/authorize',
+    redirectUri: window.location.origin || window.location.protocol + '//' + window.location.host,
+    requiredUrlParams: ['scope'],
+    scope: ['basic'],
+    scopeDelimiter: '+',
+    display: 'popup',
+    type: '2.0',
+    popupOptions: {
+      width: 550,
+      height: 369
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -309,17 +309,17 @@ authHeader: 'Authorization',
 // The token name used in the header of API requests that require authentication
 authToken: 'Bearer',
 // The the property from which to get the authentication token after a successful login or signup
-responseTokenProp: 'access_token',
-// Prepended to the `tokenName` when kept in storage (nothing to do with access token responses)
-tokenPrefix: 'aurelia',
+accessTokenProp: 'access_token',
+// Prepended to the `accessTokenName` when kept in storage (nothing to do with access token responses)
+accessTokenPrefix: 'aurelia',
 
-// If the property defined by `responseTokenProp` is an object:
+// If the property defined by `accessTokenProp` is an object:
 // ------------------------------------------------------------
 
-//This is the property from which to get the token `{ "responseTokenProp": { "tokenName" : '...' } }`
-tokenName: 'token',
-// This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
-tokenRoot: false,
+//This is the property from which to get the token `{ "accessTokenProp": { "accessTokenName" : '...' } }`
+accessTokenName: 'token',
+// This allows the token to be a further object deeper `{ "accessTokenProp": { "accessTokenRoot" : { "accessTokenName" : '...' } } }`
+accessTokenRoot: false,
 
 
 // Refresh Token Options

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -74,11 +74,15 @@ export class Authentication {
     }
 
     if (!token && response) {
-      token = this.config.tokenRoot && response[this.config.tokenRoot] ? response[this.config.tokenRoot][this.config.tokenName] : response[this.config.tokenName];
+      token = this.config.tokenRoot && response[this.config.tokenRoot]
+        ? response[this.config.tokenRoot][this.config.tokenName]
+        : response[this.config.tokenName];
     }
 
     if (!token) {
-      let tokenPath = this.config.tokenRoot ? this.config.tokenRoot + '.' + this.config.tokenName : this.config.tokenName;
+      let tokenPath = this.config.tokenRoot
+        ? this.config.tokenRoot + '.' + this.config.tokenName
+        : this.config.tokenName;
 
       throw new Error('Expecting a token named "' + tokenPath + '" but instead got: ' + JSON.stringify(response));
     }
@@ -94,8 +98,7 @@ export class Authentication {
 
   setRefreshTokenFromResponse(response) {
     let refreshTokenName = this.refreshTokenName;
-    let refreshToken     = response && response.refresh_token;
-    let refreshTokenPath;
+    let refreshToken     = response && response[this.config.refreshTokenProp];
     let token;
 
     if (refreshToken) {
@@ -112,7 +115,7 @@ export class Authentication {
         : response[this.config.refreshTokenName];
     }
     if (!token) {
-      refreshTokenPath = this.config.refreshTokenRoot
+      let refreshTokenPath = this.config.refreshTokenRoot
         ? this.config.refreshTokenRoot + '.' + this.config.refreshTokenName
         : this.config.refreshTokenName;
 

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -15,7 +15,7 @@ export class Authentication {
   }
 
   get tokenName() {
-    return this.config.tokenPrefix ? this.config.tokenPrefix + '_' + this.config.tokenName : this.config.tokenName;
+    return this.config.accessTokenPrefix ? this.config.accessTokenPrefix + '_' + this.config.accessTokenName : this.config.accessTokenName;
   }
 
   getLoginRoute() {
@@ -61,8 +61,8 @@ export class Authentication {
   }
 
   setTokenFromResponse(response, redirect) {
-    let tokenName   = this.tokenName;
-    let accessToken = response && response[this.config.responseTokenProp];
+    let accessTokenName = this.accessTokenName;
+    let accessToken     = response && response[this.config.accessTokenProp];
     let token;
 
     if (accessToken) {
@@ -74,20 +74,20 @@ export class Authentication {
     }
 
     if (!token && response) {
-      token = this.config.tokenRoot && response[this.config.tokenRoot]
-        ? response[this.config.tokenRoot][this.config.tokenName]
-        : response[this.config.tokenName];
+      token = this.config.accessTokenRoot && response[this.config.accessTokenRoot]
+        ? response[this.config.accessTokenRoot][this.config.accessTokenName]
+        : response[this.config.accessTokenName];
     }
 
     if (!token) {
-      let tokenPath = this.config.tokenRoot
-        ? this.config.tokenRoot + '.' + this.config.tokenName
-        : this.config.tokenName;
+      let accessTokenPath = this.config.accessTokenRoot
+        ? this.config.accessTokenRoot + '.' + this.config.accessTokenName
+        : this.config.accessTokenName;
 
-      throw new Error('Expecting a token named "' + tokenPath + '" but instead got: ' + JSON.stringify(response));
+      throw new Error('Expecting a token named "' + accessTokenPath + '" but instead got: ' + JSON.stringify(response));
     }
 
-    this.storage.set(tokenName, token);
+    this.storage.set(accessTokenName, token);
 
     if (this.config.loginRedirect && !redirect) {
       window.location.href = this.config.loginRedirect;

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -55,21 +55,6 @@ export class BaseConfig {
       // The HTTP method used for 'unlink' requests (Options: 'get' or 'post')
       unlinkMethod: 'get',
 
-      // Refresh Token Options
-      // =====================
-
-      // Option to turn refresh tokens On/Off
-      useRefreshToken: false,
-      // The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
-      autoUpdateToken: true,
-      // This allows the refresh token to be a further object deeper `{ "responseTokenProp": { "refreshTokenRoot" : { "tokenName" : '...' } } }`
-      refreshTokenRoot: false,
-      // This is the property from which to get the token `{ "responseTokenProp": { "refreshTokenName" : '...' } }`
-      refreshTokenName: 'refresh_token',
-      // Prepended to the `refreshTokenName` when kept in storage (nothing to do with)
-      refreshTokenPrefix: 'aurelia',
-      // Oauth Client Id
-      clientId: false,
 
       // Token Related options
       // =====================
@@ -80,6 +65,8 @@ export class BaseConfig {
       authToken: 'Bearer',
       // The the property from which to get the authentication token after a successful login or signup
       responseTokenProp: 'access_token',
+      // Prepended to the `tokenName` when kept in storage (nothing to do with access token responses)
+      tokenPrefix: 'aurelia',
 
       // If the property defined by `responseTokenProp` is an object:
       // ------------------------------------------------------------
@@ -88,6 +75,29 @@ export class BaseConfig {
       tokenName: 'token',
       // This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
       tokenRoot: false,
+
+
+      // Refresh Token Options
+      // =====================
+
+      // Option to turn refresh tokens On/Off
+      useRefreshToken: false,
+      // The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
+      autoUpdateToken: true,
+      // The the property from which to get the refresh token after a successful token refresh
+      refreshTokenProp: 'refresh_token',
+      // Prepended to the `refreshTokenName` when kept in storage (nothing to do with refresh token responses)
+      refreshTokenPrefix: 'aurelia',
+      // Oauth Client Id
+      clientId: false,
+
+      // If the property defined by `refreshTokenProp` is an object:
+      // ------------------------------------------------------------
+
+      // This is the property from which to get the token `{ "refreshTokenProp": { "refreshTokenName" : '...' } }`
+      refreshTokenName: 'token',
+      // This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
+      refreshTokenRoot: false,
 
 
       // Miscellaneous Options
@@ -100,10 +110,8 @@ export class BaseConfig {
       withCredentials: true,
       // Controls how the popup is shown for different devices (Options: 'browser' or 'mobile')
       platform: 'browser',
-      // Determines the `window` property name upon which aurelia-auth data is stored (Default: `window.localStorage`)
+      // Determines the `window` property name upon which aurelia-authentication data is stored (Default: `window.localStorage`)
       storage: 'localStorage',
-      // Prepended to the `tokenName` when kept in storage (nothing to do with)
-      tokenPrefix: 'aurelia',
 
 
       //OAuth provider specific related configuration

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -64,17 +64,17 @@ export class BaseConfig {
       // The token name used in the header of API requests that require authentication
       authToken: 'Bearer',
       // The the property from which to get the authentication token after a successful login or signup
-      responseTokenProp: 'access_token',
-      // Prepended to the `tokenName` when kept in storage (nothing to do with access token responses)
-      tokenPrefix: 'aurelia',
+      accessTokenProp: 'access_token',
+      // Prepended to the `accessTokenName` when kept in storage (nothing to do with access token responses)
+      accessTokenPrefix: 'aurelia',
 
-      // If the property defined by `responseTokenProp` is an object:
+      // If the property defined by `accessTokenProp` is an object:
       // ------------------------------------------------------------
 
-      //This is the property from which to get the token `{ "responseTokenProp": { "tokenName" : '...' } }`
-      tokenName: 'token',
-      // This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
-      tokenRoot: false,
+      //This is the property from which to get the token `{ "accessTokenProp": { "accessTokenName" : '...' } }`
+      accessTokenName: 'token',
+      // This allows the token to be a further object deeper `{ "accessTokenProp": { "accessTokenRoot" : { "accessTokenName" : '...' } } }`
+      accessTokenRoot: false,
 
 
       // Refresh Token Options


### PR DESCRIPTION
FAO: @RWOverdijk  @doktordirk

DO NOT MERGE UNTIL #85 is accepted. This is currently branched off of that PR, I can rebase and force push once that is merged

We need to vote on whether [this commit](https://github.com/SpoonX/aurelia-authentication/commit/55aaab297d280b2b5822c5d58dc3d8e786333376) should be included and thus whether this PR should be accepted.

See here for details: https://gitter.im/SpoonX/Dev?at=56fe6d691720648112da43c2

I think it'd be good to standardise the names. If I understood @alfkonee correctly I believe he supports this too.
