### PR TITLE
Feat access token options

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,18 +308,18 @@ unlinkMethod: 'get',
 authHeader: 'Authorization',
 // The token name used in the header of API requests that require authentication
 authToken: 'Bearer',
-// The property name used when storing the token locally
-tokenStorage: 'aurelia_access_token',
-// The the property from which to get the authentication token after a successful login or signup
-responseTokenProp: 'access_token',
+// The property name used when storing the access token locally
+accessTokenStorage: 'aurelia_access_token',
+// The the property from which to get the access token after a successful login or signup
+accessTokenProp: 'access_token',
 
-// If the property defined by `responseTokenProp` is an object:
+// If the property defined by `accessTokenProp` is an object:
 // ------------------------------------------------------------
 
-//This is the property from which to get the token `{ "responseTokenProp": { "tokenName" : '...' } }`
-tokenName: 'token',
-// This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
-tokenRoot: false,
+//This is the property from which to get the token `{ "accessTokenProp": { "accessTokenName" : '...' } }`
+accessTokenName: 'token',
+// This allows the token to be a further object deeper `{ "accessTokenProp": { "accessTokenRoot" : { "accessTokenName" : '...' } } }`
+accessTokenRoot: false,
 
 
 // Refresh Token Options

--- a/README.md
+++ b/README.md
@@ -333,13 +333,15 @@ autoUpdateToken: true,
 clientId: false,
 // The property name used when storing the refresh token locally
 refreshTokenStorage: 'aurelia_refresh_token',
+// The the property from which to get the refresh token after a successful token refresh
+refreshTokenProp: 'refresh_token',
       
-// If `refresh_token` is an object:
-// ------------------------------------------------------------
+// If the property defined by `refreshTokenProp` is an object:
+// -----------------------------------------------------------
 
-// This is the property from which to get the token `{ "refresh_token": { "refreshTokenName" : '...' } }`
-refreshTokenName: 'refresh_token',
-// This allows the refresh token to be a further object deeper `{ "refresh_token": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
+// This is the property from which to get the token `{ "refreshTokenProp": { "refreshTokenName" : '...' } }`
+refreshTokenName: 'token',
+// This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
 refreshTokenRoot: false,
 
 

--- a/README.md
+++ b/README.md
@@ -300,29 +300,16 @@ unlinkUrl: '/auth/unlink/',
 // The HTTP method used for 'unlink' requests (Options: 'get' or 'post')
 unlinkMethod: 'get',
 
-// Refresh Token Options
-// =====================
 
-// Option to turn refresh tokens On/Off
-useRefreshToken: false,
-// The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
-autoUpdateToken: true,
-// This allows the refresh token to be a further object deeper `{ "responseTokenProp": { "refreshTokenRoot" : { "tokenName" : '...' } } }`
-refreshTokenRoot: false,
-// This is the property from which to get the token `{ "responseTokenProp": { "refreshTokenName" : '...' } }`
-refreshTokenName: 'refresh_token',
-// Prepended to the `refreshTokenName` when kept in storage (nothing to do with)
-refreshTokenPrefix: 'aurelia',
-// Oauth Client Id
-clientId: false,
-
-// Token Related options
-// =====================
+// Token Options
+// =============
 
 // The header property used to contain the authToken in the header of API requests that require authentication
 authHeader: 'Authorization',
 // The token name used in the header of API requests that require authentication
 authToken: 'Bearer',
+// The property name used when storing the token locally
+tokenStorage: 'aurelia_access_token',
 // The the property from which to get the authentication token after a successful login or signup
 responseTokenProp: 'access_token',
 
@@ -333,6 +320,27 @@ responseTokenProp: 'access_token',
 tokenName: 'token',
 // This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
 tokenRoot: false,
+
+
+// Refresh Token Options
+// =====================
+
+// Option to turn refresh tokens On/Off
+useRefreshToken: false,
+// The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
+autoUpdateToken: true,
+// Oauth Client Id
+clientId: false,
+// The property name used when storing the refresh token locally
+refreshTokenStorage: 'aurelia_refresh_token',
+      
+// If `refresh_token` is an object:
+// ------------------------------------------------------------
+
+// This is the property from which to get the token `{ "refresh_token": { "refreshTokenName" : '...' } }`
+refreshTokenName: 'refresh_token',
+// This allows the refresh token to be a further object deeper `{ "refresh_token": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
+refreshTokenRoot: false,
 
 
 // Miscellaneous Options
@@ -347,8 +355,6 @@ withCredentials: true,
 platform: 'browser',
 // Determines the `window` property name upon which aurelia-authentication data is stored (Default: `window.localStorage`)
 storage: 'localStorage',
-// Prepended to the `tokenName` when kept in storage (nothing to do with)
-tokenPrefix: 'aurelia',
 
 
 // OAuth provider specific related configuration
@@ -435,6 +441,18 @@ providers: {
     display: 'popup',
     type: '2.0',
     popupOptions: { width: 500, height: 560 }
+  },
+  instagram: {
+    name: 'instagram',
+    url: '/auth/instagram',
+    authorizationEndpoint: 'https://api.instagram.com/oauth/authorize',
+    redirectUri: window.location.origin || window.location.protocol + '//' + window.location.host,
+    requiredUrlParams: ['scope'],
+    scope: ['basic'],
+    scopeDelimiter: '+',
+    display: 'popup',
+    type: '2.0',
+    popupOptions: { width: 550, height: 369 }
   }
 }
 ```

--- a/src/authUtils.js
+++ b/src/authUtils.js
@@ -90,10 +90,6 @@ export class authUtils {
     return obj;
   }
 
-  static addTokenPrefix(prefix = '', tokenNme) {
-    return prefix ? prefix + _  + tokenNme : tokenNme;
-  }
-
   static joinUrl(baseUrl = '', url = '') {
     if (/^(?:[a-z]+:)?\/\//i.test(url)) {
       return url;

--- a/src/authUtils.js
+++ b/src/authUtils.js
@@ -41,6 +41,34 @@ export class authUtils {
     return typeof value !== 'undefined';
   }
 
+  static isString(value) {
+    return typeof value === 'string';
+  }
+
+  static isObject(value) {
+    return value !== null && typeof value === 'object';
+  }
+
+  static isArray = Array.isArray
+
+  static isFunction(value) {
+    return typeof value === 'function';
+  }
+
+  static isBlankObject(value) {
+    return value !== null && typeof value === 'object' && !Object.getPrototypeOf(value);
+  }
+
+  static isArrayLike(obj) {
+    if (obj === null || authUtils.isWindow(obj)) {
+      return false;
+    }
+  }
+
+  static isWindow(obj) {
+    return obj && obj.window === obj;
+  }
+
   static camelCase(name) {
     return name.replace(/([\:\-\_]+(.))/g, function(_, separator, letter, offset) {
       return offset ? letter.toUpperCase() : letter;
@@ -62,21 +90,11 @@ export class authUtils {
     return obj;
   }
 
-  static isString(value) {
-    return typeof value === 'string';
+  static addTokenPrefix(prefix = '', tokenNme) {
+    return prefix ? prefix + _  + tokenNme : tokenNme;
   }
 
-  static isObject(value) {
-    return value !== null && typeof value === 'object';
-  }
-
-  static isArray = Array.isArray
-
-  static isFunction(value) {
-    return typeof value === 'function';
-  }
-
-  static joinUrl(baseUrl, url) {
+  static joinUrl(baseUrl = '', url = '') {
     if (/^(?:[a-z]+:)?\/\//i.test(url)) {
       return url;
     }
@@ -92,20 +110,6 @@ export class authUtils {
     };
 
     return normalize(joined);
-  }
-
-  static isBlankObject(value) {
-    return value !== null && typeof value === 'object' && !Object.getPrototypeOf(value);
-  }
-
-  static isArrayLike(obj) {
-    if (obj === null || authUtils.isWindow(obj)) {
-      return false;
-    }
-  }
-
-  static isWindow(obj) {
-    return obj && obj.window === obj;
   }
 
   static extend(dst) {

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -31,7 +31,7 @@ export class Authentication {
   }
 
   getToken() {
-    return this.storage.get(this.config.tokenStorage);
+    return this.storage.get(this.config.accessTokenStorage);
   }
 
   getRefreshToken() {
@@ -39,7 +39,7 @@ export class Authentication {
   }
 
   getPayload() {
-    let token = this.storage.get(this.config.tokenStorage);
+    let token = this.storage.get(this.config.accessTokenStorage);
 
     if (token && token.split('.').length === 3) {
       let base64Url = token.split('.')[1];
@@ -53,7 +53,7 @@ export class Authentication {
   }
 
   setTokenFromResponse(response, redirect) {
-    let accessToken = response && response[this.config.responseTokenProp];
+    let accessToken = response && response[this.config.accessTokenProp];
     let token;
 
     if (accessToken) {
@@ -65,20 +65,20 @@ export class Authentication {
     }
 
     if (!token && response) {
-      token = this.config.tokenRoot && response[this.config.tokenRoot]
-        ? response[this.config.tokenRoot][this.config.tokenName]
-        : response[this.config.tokenName];
+      token = this.config.accessTokenRoot && response[this.config.accessTokenRoot]
+        ? response[this.config.accessTokenRoot][this.config.accessTokenName]
+        : response[this.config.accessTokenName];
     }
 
     if (!token) {
-      let tokenPath = this.config.tokenRoot
-        ? this.config.tokenRoot + '.' + this.config.tokenName
-        : this.config.tokenName;
+      let accessTokenPath = this.config.accessTokenRoot
+        ? this.config.accessTokenRoot + '.' + this.config.accessTokenName
+        : this.config.accessTokenName;
 
-      throw new Error('Expecting a token named "' + tokenPath + '" but instead got: ' + JSON.stringify(response));
+      throw new Error('Expecting a token named "' + accessTokenPath + '" but instead got: ' + JSON.stringify(response));
     }
 
-    this.storage.set(this.config.tokenStorage, token);
+    this.storage.set(this.config.accessTokenStorage, token);
 
     if (this.config.loginRedirect && !redirect) {
       window.location.href = this.config.loginRedirect;
@@ -117,7 +117,7 @@ export class Authentication {
   }
 
   removeToken() {
-    this.storage.remove(this.config.tokenStorage);
+    this.storage.remove(this.config.accessTokenStorage);
   }
 
   removeRefreshToken() {
@@ -125,7 +125,7 @@ export class Authentication {
   }
 
   isAuthenticated() {
-    let token = this.storage.get(this.config.tokenStorage);
+    let token = this.storage.get(this.config.accessTokenStorage);
 
     // There's no token, so user is not authenticated.
     if (!token) {
@@ -167,7 +167,7 @@ export class Authentication {
 
   logout(redirect) {
     return new Promise(resolve => {
-      this.storage.remove(this.config.tokenStorage);
+      this.storage.remove(this.config.accessTokenStorage);
       this.storage.remove(this.config.refreshTokenStorage);
 
       if (this.config.logoutRedirect && !redirect) {

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -11,11 +11,11 @@ export class Authentication {
   }
 
   get refreshTokenName() {
-    return this.config.refreshTokenPrefix ? this.config.refreshTokenPrefix + '_' + this.config.refreshTokenName : this.config.refreshTokenName;
+    return authUtils.addTokenPrefix(this.config.refreshTokenPrefix, this.config.refreshTokenName);
   }
 
   get tokenName() {
-    return this.config.tokenPrefix ? this.config.tokenPrefix + '_' + this.config.tokenName : this.config.tokenName;
+    return authUtils.addTokenPrefix(this.config.tokenPrefix, this.config.tokenName);
   }
 
   getLoginRoute() {
@@ -27,15 +27,15 @@ export class Authentication {
   }
 
   getLoginUrl() {
-    return this.config.baseUrl ? authUtils.joinUrl(this.config.baseUrl, this.config.loginUrl) : this.config.loginUrl;
+    return authUtils.joinUrl(this.config.baseUrl, this.config.loginUrl);
   }
 
   getSignupUrl() {
-    return this.config.baseUrl ? authUtils.joinUrl(this.config.baseUrl, this.config.signupUrl) : this.config.signupUrl;
+    return authUtils.joinUrl(this.config.baseUrl, this.config.signupUrl);
   }
 
   getProfileUrl() {
-    return this.config.baseUrl ? authUtils.joinUrl(this.config.baseUrl, this.config.profileUrl) : this.config.profileUrl;
+    return authUtils.joinUrl(this.config.baseUrl, this.config.profileUrl);
   }
 
   getToken() {

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -88,7 +88,7 @@ export class Authentication {
   }
 
   setRefreshTokenFromResponse(response) {
-    let refreshToken = response && response.refresh_token;
+    let refreshToken = response && response[this.config.refreshTokenProp];
     let token;
 
     if (refreshToken) {

--- a/src/authorizeStep.js
+++ b/src/authorizeStep.js
@@ -4,20 +4,20 @@ import {Redirect} from 'aurelia-router';
 
 @inject(Authentication)
 export class AuthorizeStep {
-  constructor(auth) {
-    this.auth = auth;
+  constructor(authentication) {
+    this.authentication = authentication;
   }
 
   run(routingContext, next) {
-    let isLoggedIn = this.auth.isAuthenticated();
-    let loginRoute = this.auth.getLoginRoute();
+    let isLoggedIn = this.authentication.isAuthenticated();
+    let loginRoute = this.authentication.getLoginRoute();
 
     if (routingContext.getAllInstructions().some(i => i.config.auth)) {
       if (!isLoggedIn) {
         return next.cancel(new Redirect(loginRoute));
       }
     } else if (isLoggedIn && routingContext.getAllInstructions().some(i => i.fragment === loginRoute)) {
-      let loginRedirect = this.auth.getLoginRedirect();
+      let loginRedirect = this.authentication.getLoginRedirect();
       return next.cancel(new Redirect(loginRedirect));
     }
 

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -55,29 +55,16 @@ export class BaseConfig {
       // The HTTP method used for 'unlink' requests (Options: 'get' or 'post')
       unlinkMethod: 'get',
 
-      // Refresh Token Options
-      // =====================
 
-      // Option to turn refresh tokens On/Off
-      useRefreshToken: false,
-      // The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
-      autoUpdateToken: true,
-      // This allows the refresh token to be a further object deeper `{ "responseTokenProp": { "refreshTokenRoot" : { "tokenName" : '...' } } }`
-      refreshTokenRoot: false,
-      // This is the property from which to get the token `{ "responseTokenProp": { "refreshTokenName" : '...' } }`
-      refreshTokenName: 'refresh_token',
-      // Prepended to the `refreshTokenName` when kept in storage (nothing to do with)
-      refreshTokenPrefix: 'aurelia',
-      // Oauth Client Id
-      clientId: false,
-
-      // Token Related options
-      // =====================
+      // Token Options
+      // =============
 
       // The header property used to contain the authToken in the header of API requests that require authentication
       authHeader: 'Authorization',
       // The token name used in the header of API requests that require authentication
       authToken: 'Bearer',
+      // The property name used when storing the token locally
+      tokenStorage: 'aurelia_access_token',
       // The the property from which to get the authentication token after a successful login or signup
       responseTokenProp: 'access_token',
 
@@ -90,6 +77,27 @@ export class BaseConfig {
       tokenRoot: false,
 
 
+      // Refresh Token Options
+      // =====================
+
+      // Option to turn refresh tokens On/Off
+      useRefreshToken: false,
+      // The option to enable/disable the automatic refresh of Auth tokens using Refresh Tokens
+      autoUpdateToken: true,
+      // Oauth Client Id
+      clientId: false,
+      // The property name used when storing the refresh token locally
+      refreshTokenStorage: 'aurelia_refresh_token',
+
+      // If `refresh_token` is an object:
+      // ------------------------------------------------------------
+
+      // This is the property from which to get the token `{ "refresh_token": { "refreshTokenName" : '...' } }`
+      refreshTokenName: 'refresh_token',
+      // This allows the refresh token to be a further object deeper `{ "refresh_token": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
+      refreshTokenRoot: false,
+
+
       // Miscellaneous Options
       // =====================
 
@@ -100,10 +108,8 @@ export class BaseConfig {
       withCredentials: true,
       // Controls how the popup is shown for different devices (Options: 'browser' or 'mobile')
       platform: 'browser',
-      // Determines the `window` property name upon which aurelia-auth data is stored (Default: `window.localStorage`)
+      // Determines the `window` property name upon which aurelia-authentication data is stored (Default: `window.localStorage`)
       storage: 'localStorage',
-      // Prepended to the `tokenName` when kept in storage (nothing to do with)
-      tokenPrefix: 'aurelia',
 
 
       //OAuth provider specific related configuration

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -88,13 +88,15 @@ export class BaseConfig {
       clientId: false,
       // The property name used when storing the refresh token locally
       refreshTokenStorage: 'aurelia_refresh_token',
+      // The the property from which to get the refresh token after a successful token refresh
+      refreshTokenProp: 'refresh_token',
 
-      // If `refresh_token` is an object:
-      // ------------------------------------------------------------
+      // If the property defined by `refreshTokenProp` is an object:
+      // -----------------------------------------------------------
 
-      // This is the property from which to get the token `{ "refresh_token": { "refreshTokenName" : '...' } }`
-      refreshTokenName: 'refresh_token',
-      // This allows the refresh token to be a further object deeper `{ "refresh_token": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
+      // This is the property from which to get the token `{ "refreshTokenProp": { "refreshTokenName" : '...' } }`
+      refreshTokenName: 'token',
+      // This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
       refreshTokenRoot: false,
 
 

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -63,18 +63,18 @@ export class BaseConfig {
       authHeader: 'Authorization',
       // The token name used in the header of API requests that require authentication
       authToken: 'Bearer',
-      // The property name used when storing the token locally
-      tokenStorage: 'aurelia_access_token',
-      // The the property from which to get the authentication token after a successful login or signup
-      responseTokenProp: 'access_token',
+      // The property name used when storing the access token locally
+      accessTokenStorage: 'aurelia_access_token',
+      // The the property from which to get the access token after a successful login or signup
+      accessTokenProp: 'access_token',
 
-      // If the property defined by `responseTokenProp` is an object:
+      // If the property defined by `accessTokenProp` is an object:
       // ------------------------------------------------------------
 
-      //This is the property from which to get the token `{ "responseTokenProp": { "tokenName" : '...' } }`
-      tokenName: 'token',
-      // This allows the token to be a further object deeper `{ "responseTokenProp": { "tokenRoot" : { "tokenName" : '...' } } }`
-      tokenRoot: false,
+      //This is the property from which to get the token `{ "accessTokenProp": { "accessTokenName" : '...' } }`
+      accessTokenName: 'token',
+      // This allows the token to be a further object deeper `{ "accessTokenProp": { "accessTokenRoot" : { "accessTokenName" : '...' } } }`
+      accessTokenRoot: false,
 
 
       // Refresh Token Options

--- a/src/popup.js
+++ b/src/popup.js
@@ -25,7 +25,7 @@ export class Popup {
   }
 
   eventListener(redirectUri) {
-    let promise = new Promise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       this.popupWindow.addEventListener('loadstart', event => {
         if (event.url.indexOf(redirectUri) !== 0) {
           return;
@@ -43,9 +43,7 @@ export class Popup {
           authUtils.extend(qs, hash);
 
           if (qs.error) {
-            reject({
-              error: qs.error
-            });
+            reject({error: qs.error});
           } else {
             resolve(qs);
           }
@@ -55,19 +53,13 @@ export class Popup {
       });
 
       this.popupWindow.addEventListener('exit', () => {
-        reject({
-          data: 'Provider Popup was closed'
-        });
+        reject({data: 'Provider Popup was closed'});
       });
 
       this.popupWindow.addEventListener('loaderror', () => {
-        deferred.reject({
-          data: 'Authorization Failed'
-        });
+        reject({data: 'Authorization Failed'});
       });
     });
-
-    return promise;
   }
 
   pollPopup() {
@@ -88,9 +80,7 @@ export class Popup {
             authUtils.extend(qs, hash);
 
             if (qs.error) {
-              reject({
-                error: qs.error
-              });
+              reject({error: qs.error});
             } else {
               resolve(qs);
             }


### PR DESCRIPTION
Replaces PR #86. Based upon #92 

See commit message:

>   feat(baseConfig): standardize access token option names (breaking)
> 
> BREAKING CHANGE: This aligns access token option names with the refresh token option names. The option changes are as follows:
> 
> ```
> tokenStorage      => accessTokenStorage
> responseTokenProp => accessTokenProp
> tokenName         => accessTokenName
> tokenRoot         => accessTokenRoot
> ```
