### PR TITLE
chore(project): Remove Fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,12 @@
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0-beta.1.2.0",
       "aurelia-fetch-client": "npm:aurelia-fetch-client@^1.0.0-beta.1.2.0",
       "aurelia-router": "npm:aurelia-router@^1.0.0-beta.1.2.0",
-      "fetch": "github:github/fetch@^0.11.0",
       "spoonx/aurelia-api": "github:spoonx/aurelia-api@^2.1.2"
     },
     "peerDependencies": {
       "aurelia-dependency-injection": "npm:aurelia-dependency-injection@^1.0.0-beta.1.2.0",
       "aurelia-fetch-client": "npm:aurelia-fetch-client@^1.0.0-beta.1.2.0",
       "aurelia-router": "npm:aurelia-router@^1.0.0-beta.1.2.0",
-      "fetch": "github:github/fetch@^0.11.0",
       "spoonx/aurelia-api": "github:spoonx/aurelia-api@^2.1.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Fetch shouldn't be a hard dependency. You decide which fetch client to use in your app. Dev does need fetch client for the tests
