### PR TITLE
feat(authService): add profileMethod config option

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -52,7 +52,10 @@ export class AuthService {
     if (typeof criteria === 'string' || typeof criteria === 'number') {
       criteria = { id: criteria };
     }
-    return this.client.update(this.config.withBase(this.config.profileUrl), criteria, body);
+    if (this.config.profileMethod === 'put') {
+      return this.client.update(this.config.withBase(this.config.profileUrl), criteria, body);
+    }
+    return this.client.patch(this.config.withBase(this.config.profileUrl), criteria, body);
   }
 
   /**

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -67,6 +67,8 @@ export class BaseConfig {
   signupUrl = '/auth/signup';
   // The API endpoint used in profile requests (inc. `find/get` and `update`)
   profileUrl = '/auth/me';
+  // The method used to update the profile ('put' or 'patch')
+  profileMethod = 'put';
   // The API endpoint used with oAuth to unlink authentication
   unlinkUrl = '/auth/unlink/';
   // The HTTP method used for 'unlink' requests (Options: 'get' or 'post')

--- a/test/authService.spec.js
+++ b/test/authService.spec.js
@@ -84,10 +84,14 @@ describe('AuthService', () => {
   });
 
 
-  describe('.updateMe()', () => {
+  describe('.updateMe() with PUT', () => {
     const container      = getContainer();
     const authService    = container.get(AuthService);
-
+    
+    beforeEach(() => {
+      authService.config.profileMethod = 'put';
+    });
+    
     it('without criteria', done => {
       authService.updateMe({data: 'some'})
         .then(result => {
@@ -125,6 +129,60 @@ describe('AuthService', () => {
       authService.updateMe({data: 'some'}, {foo: 'bar'})
         .then(result => {
           expect(result.method).toBe('PUT');
+          expect(result.path).toBe('/auth/me');
+          expect(result.query.foo).toBe('bar');
+          expect(result.body.data).toBe('some');
+          done();
+        });
+    });
+  });
+
+
+  describe('.updateMe() with PATCH', () => {
+    const container      = getContainer();
+    const authService    = container.get(AuthService);
+    
+    beforeEach(() => {
+      authService.config.profileMethod = 'patch';
+    });
+
+    it('without criteria', done => {
+      authService.updateMe({data: 'some'})
+        .then(result => {
+          expect(result.method).toBe('PATCH');
+          expect(result.path).toBe('/auth/me');
+          expect(JSON.stringify(result.query)).toBe('{}');
+          expect(result.body.data).toBe('some');
+          done();
+        });
+    });
+
+    it('with criteria a number', done => {
+      authService.updateMe({data: 'some'}, 5)
+        .then(result => {
+          expect(result.method).toBe('PATCH');
+          expect(result.path).toBe('/auth/me');
+          expect(result.query.id).toBe('5');
+          expect(result.body.data).toBe('some');
+          done();
+        });
+    });
+
+    it('with criteria a string', done => {
+      authService.updateMe({data: 'some'}, 'five')
+        .then(result => {
+          expect(result.method).toBe('PATCH');
+          expect(result.path).toBe('/auth/me');
+          expect(result.query.id).toBe('five');
+          expect(result.body.data).toBe('some');
+          done();
+        });
+    });
+
+    it('with criteria an object', done => {
+      authService.updateMe({data: 'some'}, {foo: 'bar'})
+        .then(result => {
+          expect(result.method).toBe('PATCH');
           expect(result.path).toBe('/auth/me');
           expect(result.query.foo).toBe('bar');
           expect(result.body.data).toBe('some');


### PR DESCRIPTION
Supports a new config property 'profileMethod' that controls
the HTTP method used for AuthService.updateMe().
