### PR TITLE
fix(popup): removed '#' character from hash fragment in popup redirect URL

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -114,5 +114,7 @@ const buildPopupWindowOptions = options => {
 };
 
 const parseUrl = url => {
-  return extend(true, {}, parseQueryString(url.search), parseQueryString(url.hash));
+  let hash = (url.hash.charAt(0) === '#') ? url.hash.substr(1) : url.hash;
+
+  return extend(true, {}, parseQueryString(url.search), parseQueryString(hash));
 };


### PR DESCRIPTION
Removed '#' character from the "hash" fragment before passing string to aurelia-path's parseQueryString() function.

For consistency, a similar thing was done to the "search" property (i.e. the '?' character is removed), although aurelia-path does this anyway.
