### PR TITLE
fix(oauth implicit): removed encoding of space character between implicit response types when returning token from popup

### DIFF
--- a/src/oAuth2.js
+++ b/src/oAuth2.js
@@ -48,8 +48,8 @@ export class OAuth2 {
     return openPopup
       .then(oauthData => {
         if (provider.responseType === 'token' ||
-            provider.responseType === 'id_token%20token' ||
-            provider.responseType === 'token%20id_token'
+            provider.responseType === 'id_token token' ||
+            provider.responseType === 'token id_token'
         ) {
           return oauthData;
         }


### PR DESCRIPTION
Work was done by @Vidarls in aurelia-auth to add support for OpenID (https://github.com/paulvanbladel/aurelia-auth/issues/28#issuecomment-152566938). Basically, if the provider's response type is"id_token%20token" or "token%20id_token", then implicit flow is assumed and the token is returned directly from the popup - otherwise code flow occurred and a code/token exchange needs to take place via a POST request. 

In order for this to work as written, the `responseType` property of the `providers` configuration also has to have the spaces encoded.

Unfortunately, when the URL for the popup is created, the `responseType` is encoded by aurelia-path, which results in the "%20" being encoded again, so the response type sent to Identity Server in the URL actually becomes "id_token%2520token" - which Identity Server correctly rejects as an invalid response type.  Example popup URL:

https://identity.local/connect/authorize?client_id=portal-web&display=popup&response_type=id_token%2520token&scope=openid%20profile%20email

This PR fixes the issue; response types should be separated by spaces and not require the encoding.
