### PR TITLE
Fix isAuthenticated and other tab login/logout

### DIFF
--- a/doc/Quick start.md
+++ b/doc/Quick start.md
@@ -80,6 +80,13 @@ export function configure(aurelia) {
 }
 ```
 
+### Getting the current authentication status
+
+There are two options:
+
+* authService.isAuthenticated(): This function gets the current token on each call from the window storage to calucate the current authentication status. Since it's a function, Aurelia will use dirty checking, if you bind to it.
+* authService.authenticated: This property gets updated by timeout and storage events to keep it accurate all the time. No dirty-checking is needed, but you might not like that there is magic used to keep it updated.
+
 ### Provide a UI for a login, signup and profile
 
 Button actions are passed to the corresponding view model via a simple click.delegate:

--- a/doc/api_authService.md
+++ b/doc/api_authService.md
@@ -44,9 +44,9 @@ import {AuthService} from 'aurelia-authentication';
 
 ### .authenticated
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | Authentication status as set by timeout function |
+| Type    | Description                                 |
+| ------- | ------------------------------------------- |
+| Boolean | Automatically updated authentication status |
 
 ----------
 

--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -23,8 +23,10 @@ loginRoute = '/login';
 loginOnSignup = true;
 // If loginOnSignup == false: The SPA url to which the user is redirected after a successful signup (else loginRedirect is used)
 signupRedirect = '#/login';
-// redirect  when token expires. 0 = don't redirect (default), 1 = use logoutRedirect, string = redirect there
-expiredRedirect = 0;
+// reload page when token expires. 0 = don't reload (default), 1 = do reload page
+expiredReload = 0;
+// reload page when storage changed aka login/logout in other tabs/windows. 0 = don't reload (default), 1 = do reload page
+storageChangedReload = 0;
 
 
 // API related options

--- a/src/authService.js
+++ b/src/authService.js
@@ -207,6 +207,8 @@ export class AuthService {
   * @returns {Boolean} For Non-JWT and unexpired JWT: true, else: false
   */
   isAuthenticated() {
+    this.authentication.hasTokenAnalyzed = false;
+
     let authenticated = this.authentication.isAuthenticated();
 
     // auto-update token?

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -1,4 +1,5 @@
 import {PLATFORM} from 'aurelia-pal';
+import {buildQueryString} from 'aurelia-path';
 import {inject} from 'aurelia-dependency-injection';
 import {deprecated} from 'aurelia-metadata';
 import jwtDecode from 'jwt-decode';
@@ -23,7 +24,7 @@ export class Authentication {
     this.idToken              = null;
     this.payload              = null;
     this.exp                  = null;
-    this.hasTokenAnalyzed     = false;
+    this.responseAnalyzed     = false;
   }
 
 
@@ -86,7 +87,7 @@ export class Authentication {
     this.idToken          = null;
     this.payload          = null;
     this.exp              = null;
-    this.hasTokenAnalyzed = false;
+    this.responseAnalyzed = false;
 
     this.storage.remove(this.config.storageKey);
   }
@@ -95,27 +96,27 @@ export class Authentication {
   /* get data, update if needed first */
 
   getAccessToken() {
-    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
+    if (!this.responseAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.accessToken;
   }
 
   getRefreshToken() {
-    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
+    if (!this.responseAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
   }
 
   getIdToken() {
-    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
+    if (!this.responseAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.idToken;
   }
 
   getPayload() {
-    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
+    if (!this.responseAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.payload;
   }
 
   getExp() {
-    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
+    if (!this.responseAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.exp;
   }
 
@@ -169,7 +170,7 @@ export class Authentication {
 
     this.exp = this.payload ? parseInt(this.payload.exp, 10) : NaN;
 
-    this.hasTokenAnalyzed = true;
+    this.responseAnalyzed = true;
 
     return {
       accessToken: this.accessToken,
@@ -243,7 +244,7 @@ export class Authentication {
     return providerLogin.open(this.config.providers[name], userData);
   }
 
-  redirect(redirectUrl, defaultRedirectUrl) {
+  redirect(redirectUrl, defaultRedirectUrl, query) {
     // stupid rule to keep it BC
     if (redirectUrl === true) {
       LogManager.getLogger('authentication').warn('DEPRECATED: Setting redirectUrl === true to actually *not redirect* is deprecated. Set redirectUrl === 0 instead.');
@@ -258,9 +259,9 @@ export class Authentication {
       return;
     }
     if (typeof redirectUrl === 'string') {
-      PLATFORM.location.href = encodeURI(redirectUrl);
+      PLATFORM.location.href = encodeURI(redirectUrl + (query ? `?${buildQueryString(query)}` : ''));
     } else if (defaultRedirectUrl) {
-      PLATFORM.location.href = defaultRedirectUrl;
+      PLATFORM.location.href = defaultRedirectUrl + (query ? `?${buildQueryString(query)}` : '');
     }
   }
 }

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -23,7 +23,7 @@ export class Authentication {
     this.idToken              = null;
     this.payload              = null;
     this.exp                  = null;
-    this.hasDataStored        = false;
+    this.hasTokenAnalyzed     = false;
   }
 
 
@@ -81,13 +81,12 @@ export class Authentication {
       this.storage.set(this.config.storageKey, JSON.stringify(response));
       return;
     }
-    this.accessToken = null;
-    this.refreshToken = null;
-    this.idToken = null;
-    this.payload = null;
-    this.exp = null;
-
-    this.hasDataStored = false;
+    this.accessToken      = null;
+    this.refreshToken     = null;
+    this.idToken          = null;
+    this.payload          = null;
+    this.exp              = null;
+    this.hasTokenAnalyzed = false;
 
     this.storage.remove(this.config.storageKey);
   }
@@ -96,27 +95,27 @@ export class Authentication {
   /* get data, update if needed first */
 
   getAccessToken() {
-    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.accessToken;
   }
 
   getRefreshToken() {
-    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
   }
 
   getIdToken() {
-    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.idToken;
   }
 
   getPayload() {
-    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.payload;
   }
 
   getExp() {
-    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    if (!this.hasTokenAnalyzed) this.getDataFromResponse(this.getResponseObject());
     return this.exp;
   }
 
@@ -170,7 +169,7 @@ export class Authentication {
 
     this.exp = this.payload ? parseInt(this.payload.exp, 10) : NaN;
 
-    this.hasDataStored = true;
+    this.hasTokenAnalyzed = true;
 
     return {
       accessToken: this.accessToken,

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -58,9 +58,10 @@ export class BaseConfig {
   loginOnSignup = true;
   // If loginOnSignup == false: The SPA url to which the user is redirected after a successful signup (else loginRedirect is used)
   signupRedirect = '#/login';
-  // redirect  when token expires. 0 = don't redirect (default), 1 = use logoutRedirect, string = redirect there
-  expiredRedirect = 0;
-
+  // The SPA url to load when the token expires
+  expiredRedirect = '#/';
+  // The SPA url to load when the authentication status changed in other tabs/windows (detected through storageEvents)
+  storageChangedRedirect = '#/';
 
   // API related options
   // ===================
@@ -284,13 +285,31 @@ export class BaseConfig {
   };
 
   /* deprecated defaults */
+  /**
+   * @deprecated
+   */
   _authToken = 'Bearer';
+  /**
+   * @deprecated
+   */
   _responseTokenProp = 'access_token';
+  /**
+   * @deprecated
+   */
   _tokenName = 'token';
+  /**
+   * @deprecated
+   */
   _tokenRoot = false;
+  /**
+   * @deprecated
+   */
   _tokenPrefix = 'aurelia';
 
   /* deprecated methods and parameteres */
+  /**
+   * @deprecated
+   */
   set authToken(authToken) {
     LogManager.getLogger('authentication').warn('BaseConfig.authToken is deprecated. Use BaseConfig.authTokenType instead.');
     this._authTokenType = authToken;
@@ -301,6 +320,9 @@ export class BaseConfig {
     return this._authTokenType;
   }
 
+  /**
+   * @deprecated
+   */
   set responseTokenProp(responseTokenProp) {
     LogManager.getLogger('authentication').warn('BaseConfig.responseTokenProp is deprecated. Use BaseConfig.accessTokenProp instead.');
     this._responseTokenProp = responseTokenProp;
@@ -311,6 +333,9 @@ export class BaseConfig {
     return this._responseTokenProp;
   }
 
+  /**
+   * @deprecated
+   */
   set tokenRoot(tokenRoot) {
     LogManager.getLogger('authentication').warn('BaseConfig.tokenRoot is deprecated. Use BaseConfig.accessTokenRoot instead.');
     this._tokenRoot = tokenRoot;
@@ -321,6 +346,9 @@ export class BaseConfig {
     return this._tokenRoot;
   }
 
+  /**
+   * @deprecated
+   */
   set tokenName(tokenName) {
     LogManager.getLogger('authentication').warn('BaseConfig.tokenName is deprecated. Use BaseConfig.accessTokenName instead.');
     this._tokenName = tokenName;
@@ -331,6 +359,9 @@ export class BaseConfig {
     return this._tokenName;
   }
 
+  /**
+   * @deprecated
+   */
   set tokenPrefix(tokenPrefix) {
     LogManager.getLogger('authentication').warn('BaseConfig.tokenPrefix is obsolete. Use BaseConfig.storageKey instead.');
     this._tokenPrefix = tokenPrefix;
@@ -340,20 +371,26 @@ export class BaseConfig {
     return this._tokenPrefix || 'aurelia';
   }
 
+  /**
+   * @deprecated
+   */
   get current() {
     LogManager.getLogger('authentication').warn('Getter BaseConfig.current is deprecated. Use BaseConfig directly instead.');
     return this;
   }
   set current(_) {
-    throw new Error('Setter BaseConfig.current is obsolete. Use BaseConfig directly instead.');
+    throw new Error('Setter BaseConfig.current has been removed. Use BaseConfig directly instead.');
   }
 
+  /**
+   * @deprecated
+   */
   get _current() {
     LogManager.getLogger('authentication').warn('Getter BaseConfig._current is deprecated. Use BaseConfig directly instead.');
     return this;
   }
   set _current(_) {
-    throw new Error('Setter BaseConfig._current is obsolete. Use BaseConfig directly instead.');
+    throw new Error('Setter BaseConfig._current has been removed. Use BaseConfig directly instead.');
   }
 }
 

--- a/test/authService.spec.js
+++ b/test/authService.spec.js
@@ -483,6 +483,32 @@ describe('AuthService', () => {
       expect(typeof result).toBe('boolean');
     });
 
+    describe('should analyse token from storage each time', () => {
+      it('should be true after setResponseObject with token', () => {
+        authService.setResponseObject({token: 'some', refresh_token: 'another'});
+
+        expect(authService.isAuthenticated()).toBe(true);
+      });
+
+      it('should be false after clearing storage directly', () => {
+        authService.authentication.storage.remove(authService.config.storageKey);
+
+        expect(authService.isAuthenticated()).toBe(false);
+      });
+
+      it('should be true after setting storage directly', () => {
+        authService.authentication.storage.set(authService.config.storageKey, JSON.stringify({token: 'some', refresh_token: 'another'}));
+
+        expect(authService.isAuthenticated()).toBe(true);
+      });
+
+      it('should be false after setResponseObject with null', () => {
+        authService.setResponseObject(null);
+
+        expect(authService.isAuthenticated()).toBe(false);
+      });
+    });
+
     describe('with autoUpdateToken=true', () => {
       it('should return boolean true', () => {
         authService.setResponseObject({token: 'some', refresh_token: 'another'});

--- a/test/authentication.spec.js
+++ b/test/authentication.spec.js
@@ -349,7 +349,7 @@ describe('Authentication', () => {
     it('Should set data from non-JWT response', () => {
       authentication.getDataFromResponse({access_token: 'token'});
 
-      expect(authentication.hasTokenAnalyzed).toBe(true);
+      expect(authentication.responseAnalyzed).toBe(true);
       expect(authentication.accessToken).toBe('token');
       expect(authentication.payload).toBe(null);
       expect(Number.isNaN(authentication.exp)).toBe(true);
@@ -358,7 +358,7 @@ describe('Authentication', () => {
     it('Should set data from JWT-like response', () => {
       authentication.getDataFromResponse({access_token: 'xx.yy.zz'});
 
-      expect(authentication.hasTokenAnalyzed).toBe(true);
+      expect(authentication.responseAnalyzed).toBe(true);
       expect(authentication.accessToken).toBe('xx.yy.zz');
       expect(authentication.payload).toBe(null);
       expect(Number.isNaN(authentication.exp)).toBe(true);
@@ -367,7 +367,7 @@ describe('Authentication', () => {
     it('Should set data from JWT response', () => {
       authentication.getDataFromResponse({access_token: tokenFuture.jwt});
 
-      expect(authentication.hasTokenAnalyzed).toBe(true);
+      expect(authentication.responseAnalyzed).toBe(true);
       expect(authentication.accessToken).toBe(tokenFuture.jwt);
       expect(JSON.stringify(authentication.payload)).toBe(JSON.stringify(tokenFuture.payload));
       expect(authentication.exp).toBe(Number(tokenFuture.payload.exp));

--- a/test/authentication.spec.js
+++ b/test/authentication.spec.js
@@ -349,7 +349,7 @@ describe('Authentication', () => {
     it('Should set data from non-JWT response', () => {
       authentication.getDataFromResponse({access_token: 'token'});
 
-      expect(authentication.hasDataStored).toBe(true);
+      expect(authentication.hasTokenAnalyzed).toBe(true);
       expect(authentication.accessToken).toBe('token');
       expect(authentication.payload).toBe(null);
       expect(Number.isNaN(authentication.exp)).toBe(true);
@@ -358,7 +358,7 @@ describe('Authentication', () => {
     it('Should set data from JWT-like response', () => {
       authentication.getDataFromResponse({access_token: 'xx.yy.zz'});
 
-      expect(authentication.hasDataStored).toBe(true);
+      expect(authentication.hasTokenAnalyzed).toBe(true);
       expect(authentication.accessToken).toBe('xx.yy.zz');
       expect(authentication.payload).toBe(null);
       expect(Number.isNaN(authentication.exp)).toBe(true);
@@ -367,7 +367,7 @@ describe('Authentication', () => {
     it('Should set data from JWT response', () => {
       authentication.getDataFromResponse({access_token: tokenFuture.jwt});
 
-      expect(authentication.hasDataStored).toBe(true);
+      expect(authentication.hasTokenAnalyzed).toBe(true);
       expect(authentication.accessToken).toBe(tokenFuture.jwt);
       expect(JSON.stringify(authentication.payload)).toBe(JSON.stringify(tokenFuture.payload));
       expect(authentication.exp).toBe(Number(tokenFuture.payload.exp));


### PR DESCRIPTION
- isAuthenticated  uses values from storage
- authenticated updated on storage events and redirects if needed/desired

-new: storageChangedReload. 0/1 set to  '0' = do not redirect automatically to logout /login default pages after storage events if needed
-breaking: expiredRedirect changed to a  expiredReload 0/1
-breaking: hasDataAnalysed renamed to responseAnalysed
