### PR TITLE
Add getIdToken function to the AuthService class.

### DIFF
--- a/dist/amd/aurelia-authentication.js
+++ b/dist/amd/aurelia-authentication.js
@@ -253,6 +253,9 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
       this.refreshTokenProp = 'refresh_token';
       this.refreshTokenName = 'token';
       this.refreshTokenRoot = false;
+      this.idTokenProp = 'id_token';
+      this.idTokenName = 'token';
+      this.idTokenRoot = false;
       this.httpInterceptor = true;
       this.withCredentials = true;
       this.platform = 'browser';
@@ -678,7 +681,7 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
       var openPopup = this.config.platform === 'mobile' ? popup.eventListener(provider.redirectUri) : popup.pollPopup();
 
       return openPopup.then(function (oauthData) {
-        if (provider.responseType === 'token' || provider.responseType === 'id_token%20token' || provider.responseType === 'token%20id_token') {
+        if (provider.responseType === 'token' || provider.responseType === 'id_token token' || provider.responseType === 'token id_token') {
           return oauthData;
         }
         if (oauthData.state && oauthData.state !== _this5.storage.get(stateName)) {
@@ -750,6 +753,7 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
       this.auth0Lock = auth0Lock;
       this.updateTokenCallstack = [];
       this.accessToken = null;
+      this.idToken = null;
       this.refreshToken = null;
       this.payload = null;
       this.exp = null;
@@ -792,6 +796,7 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
       }
       this.accessToken = null;
       this.refreshToken = null;
+      this.idToken = null;
       this.payload = null;
       this.exp = null;
 
@@ -808,6 +813,11 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
     Authentication.prototype.getRefreshToken = function getRefreshToken() {
       if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
       return this.refreshToken;
+    };
+
+    Authentication.prototype.getIdToken = function getIdToken() {
+      if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+      return this.idToken;
     };
 
     Authentication.prototype.getPayload = function getPayload() {
@@ -850,8 +860,14 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
         }
       }
 
-      this.payload = null;
+      this.idToken = null;
+      try {
+        this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+      } catch (e) {
+        this.idToken = null;
+      }
 
+      this.payload = null;
       try {
         this.payload = this.accessToken ? (0, _jwtDecode2.default)(this.accessToken) : null;
       } catch (_) {
@@ -865,6 +881,7 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
       return {
         accessToken: this.accessToken,
         refreshToken: this.refreshToken,
+        idToken: this.idToken,
         payload: this.payload,
         exp: this.exp
       };
@@ -1063,6 +1080,10 @@ define(['exports', 'extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'au
 
     AuthService.prototype.getRefreshToken = function getRefreshToken() {
       return this.authentication.getRefreshToken();
+    };
+
+    AuthService.prototype.getIdToken = function getIdToken() {
+      return this.authentication.getIdToken();
     };
 
     AuthService.prototype.isAuthenticated = function isAuthenticated() {

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -5,7 +5,7 @@ define(['exports', './aurelia-authentication'], function (exports, _aureliaAuthe
     value: true
   });
   Object.keys(_aureliaAuthentication).forEach(function (key) {
-    if (key === "default") return;
+    if (key === "default" || key === "__esModule") return;
     Object.defineProperty(exports, key, {
       enumerable: true,
       get: function () {

--- a/dist/aurelia-authentication.d.ts
+++ b/dist/aurelia-authentication.d.ts
@@ -136,6 +136,9 @@ export declare class BaseConfig {
   
   // This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
   refreshTokenRoot: any;
+  idTokenProp: any;
+  idTokenName: any;
+  idTokenRoot: any;
   
   // Miscellaneous Options
   // =====================
@@ -208,6 +211,7 @@ export declare class Authentication {
   /* get data, update if needed first */
   getAccessToken(): any;
   getRefreshToken(): any;
+  getIdToken(): any;
   getPayload(): any;
   getExp(): any;
   
@@ -333,6 +337,7 @@ export declare class AuthService {
      * @returns {String} Current refreshToken
      */
   getRefreshToken(): any;
+  getIdToken(): any;
   
   /**
     * Gets authentication status

--- a/dist/commonjs/aurelia-authentication.js
+++ b/dist/commonjs/aurelia-authentication.js
@@ -238,6 +238,9 @@ var BaseConfig = exports.BaseConfig = function () {
     this.refreshTokenProp = 'refresh_token';
     this.refreshTokenName = 'token';
     this.refreshTokenRoot = false;
+    this.idTokenProp = 'id_token';
+    this.idTokenName = 'token';
+    this.idTokenRoot = false;
     this.httpInterceptor = true;
     this.withCredentials = true;
     this.platform = 'browser';
@@ -663,7 +666,7 @@ var OAuth2 = exports.OAuth2 = (_dec4 = (0, _aureliaDependencyInjection.inject)(S
     var openPopup = this.config.platform === 'mobile' ? popup.eventListener(provider.redirectUri) : popup.pollPopup();
 
     return openPopup.then(function (oauthData) {
-      if (provider.responseType === 'token' || provider.responseType === 'id_token%20token' || provider.responseType === 'token%20id_token') {
+      if (provider.responseType === 'token' || provider.responseType === 'id_token token' || provider.responseType === 'token id_token') {
         return oauthData;
       }
       if (oauthData.state && oauthData.state !== _this5.storage.get(stateName)) {
@@ -735,6 +738,7 @@ var Authentication = exports.Authentication = (_dec5 = (0, _aureliaDependencyInj
     this.auth0Lock = auth0Lock;
     this.updateTokenCallstack = [];
     this.accessToken = null;
+    this.idToken = null;
     this.refreshToken = null;
     this.payload = null;
     this.exp = null;
@@ -777,6 +781,7 @@ var Authentication = exports.Authentication = (_dec5 = (0, _aureliaDependencyInj
     }
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.payload = null;
     this.exp = null;
 
@@ -793,6 +798,11 @@ var Authentication = exports.Authentication = (_dec5 = (0, _aureliaDependencyInj
   Authentication.prototype.getRefreshToken = function getRefreshToken() {
     if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
+  };
+
+  Authentication.prototype.getIdToken = function getIdToken() {
+    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    return this.idToken;
   };
 
   Authentication.prototype.getPayload = function getPayload() {
@@ -835,8 +845,14 @@ var Authentication = exports.Authentication = (_dec5 = (0, _aureliaDependencyInj
       }
     }
 
-    this.payload = null;
+    this.idToken = null;
+    try {
+      this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+    } catch (e) {
+      this.idToken = null;
+    }
 
+    this.payload = null;
     try {
       this.payload = this.accessToken ? (0, _jwtDecode2.default)(this.accessToken) : null;
     } catch (_) {
@@ -850,6 +866,7 @@ var Authentication = exports.Authentication = (_dec5 = (0, _aureliaDependencyInj
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
+      idToken: this.idToken,
       payload: this.payload,
       exp: this.exp
     };
@@ -1048,6 +1065,10 @@ var AuthService = exports.AuthService = (_dec12 = (0, _aureliaDependencyInjectio
 
   AuthService.prototype.getRefreshToken = function getRefreshToken() {
     return this.authentication.getRefreshToken();
+  };
+
+  AuthService.prototype.getIdToken = function getIdToken() {
+    return this.authentication.getIdToken();
   };
 
   AuthService.prototype.isAuthenticated = function isAuthenticated() {

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 var _aureliaAuthentication = require('./aurelia-authentication');
 
 Object.keys(_aureliaAuthentication).forEach(function (key) {
-  if (key === "default") return;
+  if (key === "default" || key === "__esModule") return;
   Object.defineProperty(exports, key, {
     enumerable: true,
     get: function get() {

--- a/dist/es2015/aurelia-authentication.js
+++ b/dist/es2015/aurelia-authentication.js
@@ -190,6 +190,9 @@ export let BaseConfig = class BaseConfig {
     this.refreshTokenProp = 'refresh_token';
     this.refreshTokenName = 'token';
     this.refreshTokenRoot = false;
+    this.idTokenProp = 'id_token';
+    this.idTokenName = 'token';
+    this.idTokenRoot = false;
     this.httpInterceptor = true;
     this.withCredentials = true;
     this.platform = 'browser';
@@ -585,7 +588,7 @@ export let OAuth2 = (_dec4 = inject(Storage, Popup, BaseConfig), _dec4(_class5 =
     const openPopup = this.config.platform === 'mobile' ? popup.eventListener(provider.redirectUri) : popup.pollPopup();
 
     return openPopup.then(oauthData => {
-      if (provider.responseType === 'token' || provider.responseType === 'id_token%20token' || provider.responseType === 'token%20id_token') {
+      if (provider.responseType === 'token' || provider.responseType === 'id_token token' || provider.responseType === 'token id_token') {
         return oauthData;
       }
       if (oauthData.state && oauthData.state !== this.storage.get(stateName)) {
@@ -650,6 +653,7 @@ export let Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
     this.auth0Lock = auth0Lock;
     this.updateTokenCallstack = [];
     this.accessToken = null;
+    this.idToken = null;
     this.refreshToken = null;
     this.payload = null;
     this.exp = null;
@@ -702,6 +706,7 @@ export let Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
     }
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.payload = null;
     this.exp = null;
 
@@ -718,6 +723,11 @@ export let Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
   getRefreshToken() {
     if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
+  }
+
+  getIdToken() {
+    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    return this.idToken;
   }
 
   getPayload() {
@@ -760,8 +770,14 @@ export let Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
       }
     }
 
-    this.payload = null;
+    this.idToken = null;
+    try {
+      this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+    } catch (e) {
+      this.idToken = null;
+    }
 
+    this.payload = null;
     try {
       this.payload = this.accessToken ? jwtDecode(this.accessToken) : null;
     } catch (_) {
@@ -775,6 +791,7 @@ export let Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
+      idToken: this.idToken,
       payload: this.payload,
       exp: this.exp
     };
@@ -953,6 +970,10 @@ export let AuthService = (_dec12 = inject(Authentication, BaseConfig, BindingSig
 
   getRefreshToken() {
     return this.authentication.getRefreshToken();
+  }
+
+  getIdToken() {
+    return this.authentication.getIdToken();
   }
 
   isAuthenticated() {

--- a/dist/native-modules/aurelia-authentication.js
+++ b/dist/native-modules/aurelia-authentication.js
@@ -208,6 +208,9 @@ export var BaseConfig = function () {
     this.refreshTokenProp = 'refresh_token';
     this.refreshTokenName = 'token';
     this.refreshTokenRoot = false;
+    this.idTokenProp = 'id_token';
+    this.idTokenName = 'token';
+    this.idTokenRoot = false;
     this.httpInterceptor = true;
     this.withCredentials = true;
     this.platform = 'browser';
@@ -636,7 +639,7 @@ export var OAuth2 = (_dec4 = inject(Storage, Popup, BaseConfig), _dec4(_class5 =
     var openPopup = this.config.platform === 'mobile' ? popup.eventListener(provider.redirectUri) : popup.pollPopup();
 
     return openPopup.then(function (oauthData) {
-      if (provider.responseType === 'token' || provider.responseType === 'id_token%20token' || provider.responseType === 'token%20id_token') {
+      if (provider.responseType === 'token' || provider.responseType === 'id_token token' || provider.responseType === 'token id_token') {
         return oauthData;
       }
       if (oauthData.state && oauthData.state !== _this5.storage.get(stateName)) {
@@ -707,6 +710,7 @@ export var Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
     this.auth0Lock = auth0Lock;
     this.updateTokenCallstack = [];
     this.accessToken = null;
+    this.idToken = null;
     this.refreshToken = null;
     this.payload = null;
     this.exp = null;
@@ -749,6 +753,7 @@ export var Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
     }
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.payload = null;
     this.exp = null;
 
@@ -765,6 +770,11 @@ export var Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
   Authentication.prototype.getRefreshToken = function getRefreshToken() {
     if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
+  };
+
+  Authentication.prototype.getIdToken = function getIdToken() {
+    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    return this.idToken;
   };
 
   Authentication.prototype.getPayload = function getPayload() {
@@ -807,8 +817,14 @@ export var Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
       }
     }
 
-    this.payload = null;
+    this.idToken = null;
+    try {
+      this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+    } catch (e) {
+      this.idToken = null;
+    }
 
+    this.payload = null;
     try {
       this.payload = this.accessToken ? jwtDecode(this.accessToken) : null;
     } catch (_) {
@@ -822,6 +838,7 @@ export var Authentication = (_dec5 = inject(Storage, BaseConfig, OAuth1, OAuth2,
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
+      idToken: this.idToken,
       payload: this.payload,
       exp: this.exp
     };
@@ -1021,6 +1038,10 @@ export var AuthService = (_dec12 = inject(Authentication, BaseConfig, BindingSig
 
   AuthService.prototype.getRefreshToken = function getRefreshToken() {
     return this.authentication.getRefreshToken();
+  };
+
+  AuthService.prototype.getIdToken = function getIdToken() {
+    return this.authentication.getIdToken();
   };
 
   AuthService.prototype.isAuthenticated = function isAuthenticated() {

--- a/dist/system/aurelia-authentication.js
+++ b/dist/system/aurelia-authentication.js
@@ -41,6 +41,68 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
     return encodeURIComponent(rand);
   }
 
+  function configure(aurelia, config) {
+    if (!PLATFORM.location.origin) {
+      PLATFORM.location.origin = PLATFORM.location.protocol + '//' + PLATFORM.location.hostname + (PLATFORM.location.port ? ':' + PLATFORM.location.port : '');
+    }
+
+    var baseConfig = aurelia.container.get(BaseConfig);
+
+    if (typeof config === 'function') {
+      config(baseConfig);
+    } else if ((typeof config === 'undefined' ? 'undefined' : _typeof(config)) === 'object') {
+      baseConfig.configure(config);
+    }
+
+    for (var _iterator = baseConfig.globalValueConverters, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
+      var _ref;
+
+      if (_isArray) {
+        if (_i >= _iterator.length) break;
+        _ref = _iterator[_i++];
+      } else {
+        _i = _iterator.next();
+        if (_i.done) break;
+        _ref = _i.value;
+      }
+
+      var converter = _ref;
+
+      aurelia.globalResources('./' + converter);
+      LogManager.getLogger('authentication').info('Add globalResources value-converter: ' + converter);
+    }
+    var fetchConfig = aurelia.container.get(FetchConfig);
+    var clientConfig = aurelia.container.get(Config);
+
+    if (Array.isArray(baseConfig.configureEndpoints)) {
+      baseConfig.configureEndpoints.forEach(function (endpointToPatch) {
+        fetchConfig.configure(endpointToPatch);
+      });
+    }
+
+    var client = void 0;
+
+    if (baseConfig.endpoint !== null) {
+      if (typeof baseConfig.endpoint === 'string') {
+        var endpoint = clientConfig.getEndpoint(baseConfig.endpoint);
+        if (!endpoint) {
+          throw new Error('There is no \'' + (baseConfig.endpoint || 'default') + '\' endpoint registered.');
+        }
+        client = endpoint;
+      } else if (baseConfig.endpoint instanceof HttpClient) {
+        client = new Rest(baseConfig.endpoint);
+      }
+    }
+
+    if (!(client instanceof Rest)) {
+      client = new Rest(aurelia.container.get(HttpClient));
+    }
+
+    baseConfig.client = client;
+  }
+
+  _export('configure', configure);
+
   return {
     setters: [function (_extend) {
       extend = _extend.default;
@@ -258,6 +320,9 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
           this.refreshTokenProp = 'refresh_token';
           this.refreshTokenName = 'token';
           this.refreshTokenRoot = false;
+          this.idTokenProp = 'id_token';
+          this.idTokenName = 'token';
+          this.idTokenRoot = false;
           this.httpInterceptor = true;
           this.withCredentials = true;
           this.platform = 'browser';
@@ -689,7 +754,7 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
           var openPopup = this.config.platform === 'mobile' ? popup.eventListener(provider.redirectUri) : popup.pollPopup();
 
           return openPopup.then(function (oauthData) {
-            if (provider.responseType === 'token' || provider.responseType === 'id_token%20token' || provider.responseType === 'token%20id_token') {
+            if (provider.responseType === 'token' || provider.responseType === 'id_token token' || provider.responseType === 'token id_token') {
               return oauthData;
             }
             if (oauthData.state && oauthData.state !== _this5.storage.get(stateName)) {
@@ -762,6 +827,7 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
           this.auth0Lock = auth0Lock;
           this.updateTokenCallstack = [];
           this.accessToken = null;
+          this.idToken = null;
           this.refreshToken = null;
           this.payload = null;
           this.exp = null;
@@ -804,6 +870,7 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
           }
           this.accessToken = null;
           this.refreshToken = null;
+          this.idToken = null;
           this.payload = null;
           this.exp = null;
 
@@ -820,6 +887,11 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
         Authentication.prototype.getRefreshToken = function getRefreshToken() {
           if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
           return this.refreshToken;
+        };
+
+        Authentication.prototype.getIdToken = function getIdToken() {
+          if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+          return this.idToken;
         };
 
         Authentication.prototype.getPayload = function getPayload() {
@@ -862,8 +934,14 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
             }
           }
 
-          this.payload = null;
+          this.idToken = null;
+          try {
+            this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+          } catch (e) {
+            this.idToken = null;
+          }
 
+          this.payload = null;
           try {
             this.payload = this.accessToken ? jwtDecode(this.accessToken) : null;
           } catch (_) {
@@ -877,6 +955,7 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
           return {
             accessToken: this.accessToken,
             refreshToken: this.refreshToken,
+            idToken: this.idToken,
             payload: this.payload,
             exp: this.exp
           };
@@ -1078,6 +1157,10 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
 
         AuthService.prototype.getRefreshToken = function getRefreshToken() {
           return this.authentication.getRefreshToken();
+        };
+
+        AuthService.prototype.getIdToken = function getIdToken() {
+          return this.authentication.getIdToken();
         };
 
         AuthService.prototype.isAuthenticated = function isAuthenticated() {
@@ -1417,68 +1500,6 @@ System.register(['extend', 'aurelia-logging', 'jwt-decode', 'aurelia-pal', 'aure
       }()) || _class13));
 
       _export('FetchConfig', FetchConfig);
-
-      function configure(aurelia, config) {
-        if (!PLATFORM.location.origin) {
-          PLATFORM.location.origin = PLATFORM.location.protocol + '//' + PLATFORM.location.hostname + (PLATFORM.location.port ? ':' + PLATFORM.location.port : '');
-        }
-
-        var baseConfig = aurelia.container.get(BaseConfig);
-
-        if (typeof config === 'function') {
-          config(baseConfig);
-        } else if ((typeof config === 'undefined' ? 'undefined' : _typeof(config)) === 'object') {
-          baseConfig.configure(config);
-        }
-
-        for (var _iterator = baseConfig.globalValueConverters, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();;) {
-          var _ref;
-
-          if (_isArray) {
-            if (_i >= _iterator.length) break;
-            _ref = _iterator[_i++];
-          } else {
-            _i = _iterator.next();
-            if (_i.done) break;
-            _ref = _i.value;
-          }
-
-          var converter = _ref;
-
-          aurelia.globalResources('./' + converter);
-          LogManager.getLogger('authentication').info('Add globalResources value-converter: ' + converter);
-        }
-        var fetchConfig = aurelia.container.get(FetchConfig);
-        var clientConfig = aurelia.container.get(Config);
-
-        if (Array.isArray(baseConfig.configureEndpoints)) {
-          baseConfig.configureEndpoints.forEach(function (endpointToPatch) {
-            fetchConfig.configure(endpointToPatch);
-          });
-        }
-
-        var client = void 0;
-
-        if (baseConfig.endpoint !== null) {
-          if (typeof baseConfig.endpoint === 'string') {
-            var endpoint = clientConfig.getEndpoint(baseConfig.endpoint);
-            if (!endpoint) {
-              throw new Error('There is no \'' + (baseConfig.endpoint || 'default') + '\' endpoint registered.');
-            }
-            client = endpoint;
-          } else if (baseConfig.endpoint instanceof HttpClient) {
-            client = new Rest(baseConfig.endpoint);
-          }
-        }
-
-        if (!(client instanceof Rest)) {
-          client = new Rest(aurelia.container.get(HttpClient));
-        }
-
-        baseConfig.client = client;
-      }
-
-      _export('configure', configure);
     }
   };
 });

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -8,7 +8,7 @@ System.register(['./aurelia-authentication'], function (_export, _context) {
       var _exportObj = {};
 
       for (var _key in _aureliaAuthentication) {
-        if (_key !== "default") _exportObj[_key] = _aureliaAuthentication[_key];
+        if (_key !== "default" && _key !== "__esModule") _exportObj[_key] = _aureliaAuthentication[_key];
       }
 
       _export(_exportObj);

--- a/src/authService.js
+++ b/src/authService.js
@@ -193,7 +193,7 @@ export class AuthService {
   }
 
   getIdToken() {
-      return this.authentication.getIdToken();
+    return this.authentication.getIdToken();
   }
 
  /**
@@ -379,7 +379,7 @@ export class AuthService {
 
       resolve(response);
     });
-    
+
     return (this.config.logoutUrl
       ? this.client.request(this.config.logoutMethod, this.config.joinBase(this.config.logoutUrl)).then(localLogout)
       : localLogout());

--- a/src/authService.js
+++ b/src/authService.js
@@ -192,6 +192,10 @@ export class AuthService {
     return this.authentication.getRefreshToken();
   }
 
+  getIdToken() {
+      return this.authentication.getIdToken();
+  }
+
  /**
   * Gets authentication status
   *
@@ -375,7 +379,7 @@ export class AuthService {
 
       resolve(response);
     });
-
+    
     return (this.config.logoutUrl
       ? this.client.request(this.config.logoutMethod, this.config.joinBase(this.config.logoutUrl)).then(localLogout)
       : localLogout());

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -104,10 +104,10 @@ export class Authentication {
     if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
   }
- 
+
   getIdToken() {
-      if(!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
-      return this.idToken;
+    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    return this.idToken;
   }
 
   getPayload() {
@@ -155,12 +155,12 @@ export class Authentication {
         this.refreshToken = null;
       }
     }
-    
+
     this.idToken = null;
     try {
-        this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
-    } catch(e) {
-        this.idToken = null;
+      this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+    } catch (e) {
+      this.idToken = null;
     }
 
     this.payload = null;

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -19,6 +19,7 @@ export class Authentication {
     this.auth0Lock            = auth0Lock;
     this.updateTokenCallstack = [];
     this.accessToken          = null;
+    this.idToken              = null;
     this.refreshToken         = null;
     this.payload              = null;
     this.exp                  = null;
@@ -82,6 +83,7 @@ export class Authentication {
     }
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.payload = null;
     this.exp = null;
 
@@ -101,6 +103,11 @@ export class Authentication {
   getRefreshToken() {
     if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
+  }
+ 
+  getIdToken() {
+      if(!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+      return this.idToken;
   }
 
   getPayload() {
@@ -148,9 +155,15 @@ export class Authentication {
         this.refreshToken = null;
       }
     }
+    
+    this.idToken = null;
+    try {
+        this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+    } catch(e) {
+        this.idToken = null;
+    }
 
     this.payload = null;
-
     try {
       this.payload = this.accessToken ? jwtDecode(this.accessToken) : null;
     } catch (_) {_;}
@@ -162,6 +175,7 @@ export class Authentication {
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
+      idToken: this.idToken,
       payload: this.payload,
       exp: this.exp
     };

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -128,6 +128,10 @@ export class BaseConfig {
   // This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
   refreshTokenRoot = false;
 
+  idTokenProp = 'id_token';
+  idTokenName = 'token';
+  idTokenRoot = false;
+
 
   // Miscellaneous Options
   // =====================

--- a/test/authService.spec.js
+++ b/test/authService.spec.js
@@ -453,6 +453,16 @@ describe('AuthService', () => {
     });
   });
 
+  describe('.getIdToken()', () => {
+    const container = getContainer();
+    const authService = container.get(AuthService);
+
+    it('should return authentication.idToken', () => {
+      authService.setResponseObject({token: 'some', id_token: 'another'});
+      expect(authService.getIdToken()).toBe('another');
+    });
+  });
+
   describe('.isAuthenticated()', () => {
     const container   = getContainer();
     const authService = container.get(AuthService);

--- a/test/authentication.spec.js
+++ b/test/authentication.spec.js
@@ -101,6 +101,21 @@ describe('Authentication', () => {
     });
   });
 
+  describe('.getIdToken()', () => {
+    const container      = new Container();
+    const authentication = container.get(Authentication);
+
+    afterEach(() => {
+      authentication.setResponseObject(null);
+    });
+
+    it('Should analyze response first and return idToken', () => {
+      authentication.setResponseObject({access_token: 'some', id_token: 'another'});
+
+      expect(authentication.getIdToken()).toBe('another');
+    });
+  });
+
   describe('.getPayload()', () => {
     const container      = new Container();
     const authentication = container.get(Authentication);


### PR DESCRIPTION
In the OIDC session 1.0 spec, an id_token_hint parameter is a recommended parameter that should be passed to the LogoutEndpoint. http://openid.net/specs/openid-connect-session-1_0.html#RPLogout To facilitate the call, it would be useful to expose the retrieval of the id_token from local storage by including a getIdToken() method in the AuthService class.
