### PR TITLE
Add getIdToken() method to Authentication and AuthService

### DIFF
--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -58,7 +58,7 @@ unlinkMethod = 'get';
 authHeader = 'Authorization';
 // The token name used in the header of API requests that require authentication
 authTokenType = 'Bearer';
-// The the property from which to get the access token after a successful login or signup
+// The property from which to get the access token after a successful login or signup
 accessTokenProp = 'access_token';
 
 
@@ -80,7 +80,7 @@ useRefreshToken = false;
 autoUpdateToken = true;
 // Oauth Client Id
 clientId = false;
-// The the property from which to get the refresh token after a successful token refresh
+// The property from which to get the refresh token after a successful token refresh
 refreshTokenProp = 'refresh_token';
 
 // If the property defined by `refreshTokenProp` is an object:
@@ -90,6 +90,21 @@ refreshTokenProp = 'refresh_token';
 refreshTokenName = 'token';
 // This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
 refreshTokenRoot = false;
+
+
+// Id Token Options
+// =====================
+
+// The property from which to get the id token after a successful login
+idTokenProp = 'id_token';
+
+// If the property defined by `idTokenProp` is an object:
+// -----------------------------------------------------------
+
+// This is the property from which to get the token `{ "idTokenProp": { "idTokenName" : '...' } }`
+idTokenName = 'token';
+// This allows the id token to be a further object deeper `{ "idTokenProp": { "idTokenRoot" : { "idTokenName" : '...' } } }`
+idTokenRoot = false;
 
 
 // Miscellaneous Options

--- a/src/authService.js
+++ b/src/authService.js
@@ -192,6 +192,15 @@ export class AuthService {
     return this.authentication.getRefreshToken();
   }
 
+  /**
+   * Get idToken from storage
+   *
+   * @returns {String} Current idToken
+   */
+  getIdToken() {
+    return this.authentication.getIdToken();
+  }
+
  /**
   * Gets authentication status
   *

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -20,6 +20,7 @@ export class Authentication {
     this.updateTokenCallstack = [];
     this.accessToken          = null;
     this.refreshToken         = null;
+    this.idToken              = null;
     this.payload              = null;
     this.exp                  = null;
     this.hasDataStored        = false;
@@ -82,6 +83,7 @@ export class Authentication {
     }
     this.accessToken = null;
     this.refreshToken = null;
+    this.idToken = null;
     this.payload = null;
     this.exp = null;
 
@@ -101,6 +103,11 @@ export class Authentication {
   getRefreshToken() {
     if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
     return this.refreshToken;
+  }
+
+  getIdToken() {
+    if (!this.hasDataStored) this.getDataFromResponse(this.getResponseObject());
+    return this.idToken;
   }
 
   getPayload() {
@@ -149,8 +156,14 @@ export class Authentication {
       }
     }
 
-    this.payload = null;
+    this.idToken = null;
+    try {
+      this.idToken = this.getTokenFromResponse(response, config.idTokenProp, config.idTokenName, config.idTokenRoot);
+    } catch (e) {
+      this.idToken = null;
+    }
 
+    this.payload = null;
     try {
       this.payload = this.accessToken ? jwtDecode(this.accessToken) : null;
     } catch (_) {_;}
@@ -162,6 +175,7 @@ export class Authentication {
     return {
       accessToken: this.accessToken,
       refreshToken: this.refreshToken,
+      idToken: this.idToken,
       payload: this.payload,
       exp: this.exp
     };

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -128,6 +128,12 @@ export class BaseConfig {
   // This allows the refresh token to be a further object deeper `{ "refreshTokenProp": { "refreshTokenRoot" : { "refreshTokenName" : '...' } } }`
   refreshTokenRoot = false;
 
+  // The property name from which to get the user authentication token. Can also be dotted idTokenProp.idTokenName
+  idTokenProp = 'id_token';
+  // This is the property from which to get the id token `{ "idTokenProp": { "idTokenName" : '...' } }`
+  idTokenName = 'token';
+  // This allows the id_token to be a further object deeper `{ "idTokenProp": { "idTokenRoot" : { "idTokenName" : '...' } } }`
+  idTokenRoot = false;
 
   // Miscellaneous Options
   // =====================

--- a/test/authService.spec.js
+++ b/test/authService.spec.js
@@ -453,6 +453,16 @@ describe('AuthService', () => {
     });
   });
 
+  describe('.getIdToken()', () => {
+    const container = getContainer();
+    const authService = container.get(AuthService);
+
+    it('should return authentication.idToken', () => {
+      authService.setResponseObject({token: 'some', id_token: 'another'});
+      expect(authService.getIdToken()).toBe('another');
+    });
+  });
+
   describe('.isAuthenticated()', () => {
     const container   = getContainer();
     const authService = container.get(AuthService);

--- a/test/authentication.spec.js
+++ b/test/authentication.spec.js
@@ -101,6 +101,21 @@ describe('Authentication', () => {
     });
   });
 
+  describe('.getIdToken()', () => {
+    const container      = new Container();
+    const authentication = container.get(Authentication);
+
+    afterEach(() => {
+      authentication.setResponseObject(null);
+    });
+
+    it('Should analyze response first and return idToken', () => {
+      authentication.setResponseObject({access_token: 'some', id_token: 'another'});
+
+      expect(authentication.getIdToken()).toBe('another');
+    });
+  });
+
   describe('.getPayload()', () => {
     const container      = new Container();
     const authentication = container.get(Authentication);


### PR DESCRIPTION
In the OIDC session 1.0 spec, an id_token_hint parameter is a recommended parameter that should be passed to the LogoutEndpoint. http://openid.net/specs/openid-connect-session-1_0.html#RPLogout To facilitate the call, it would be useful to expose the retrieval of the id_token from local storage by including a getIdToken() method in the AuthService class.
