### PR TITLE
feat(configure): set client in baseConfig.configure

### DIFF
--- a/src/aurelia-authentication.js
+++ b/src/aurelia-authentication.js
@@ -1,6 +1,4 @@
 import {PLATFORM} from 'aurelia-pal';
-import {HttpClient} from 'aurelia-fetch-client';
-import {Config, Rest} from 'aurelia-api';
 import {BaseConfig} from './baseConfig';
 import {FetchConfig} from './fetchClientConfig';
 import * as LogManager from 'aurelia-logging';
@@ -22,7 +20,7 @@ export function configure(aurelia, config) {
     PLATFORM.location.origin = PLATFORM.location.protocol + '//' + PLATFORM.location.hostname + (PLATFORM.location.port ? ':' + PLATFORM.location.port : '');
   }
 
-  const baseConfig = aurelia.container.get(BaseConfig);
+  let baseConfig = aurelia.container.get(BaseConfig);
 
   if (typeof config === 'function') {
     config(baseConfig);
@@ -35,8 +33,8 @@ export function configure(aurelia, config) {
     aurelia.globalResources(`./${converter}`);
     LogManager.getLogger('authentication').info(`Add globalResources value-converter: ${converter}`);
   }
-  const fetchConfig  = aurelia.container.get(FetchConfig);
-  const clientConfig = aurelia.container.get(Config);
+
+  let fetchConfig  = aurelia.container.get(FetchConfig);
 
   // Array? Configure the provided endpoints.
   if (Array.isArray(baseConfig.configureEndpoints)) {
@@ -44,27 +42,4 @@ export function configure(aurelia, config) {
       fetchConfig.configure(endpointToPatch);
     });
   }
-
-  let client;
-
-  // Let's see if there's a configured named or default endpoint or a HttpClient.
-  if (baseConfig.endpoint !== null) {
-    if (typeof baseConfig.endpoint === 'string') {
-      const endpoint = clientConfig.getEndpoint(baseConfig.endpoint);
-      if (!endpoint) {
-        throw new Error(`There is no '${baseConfig.endpoint || 'default'}' endpoint registered.`);
-      }
-      client = endpoint;
-    } else if (baseConfig.endpoint instanceof HttpClient) {
-      client = new Rest(baseConfig.endpoint);
-    }
-  }
-
-  // No? Fine. Default to HttpClient. BC all the way.
-  if (!(client instanceof Rest)) {
-    client = new Rest(aurelia.container.get(HttpClient));
-  }
-
-  // Set the client on the config, for use throughout the plugin.
-  baseConfig.client = client;
 }

--- a/test/aurelia-authentication.spec.js
+++ b/test/aurelia-authentication.spec.js
@@ -123,6 +123,7 @@ describe('aurelia-authentication', function() {
 
       expect(baseConfig.endpoint).toEqual('sx/custom');
       expect(baseConfig.client).toBe(clientConfig.getEndpoint('sx/custom'));
+      expect(baseConfig.client.endpoint).toBe('sx/custom');
     });
 
     it('Should set the default endpoint as a client.', function() {
@@ -134,6 +135,19 @@ describe('aurelia-authentication', function() {
 
       expect(baseConfig.endpoint).toEqual('');
       expect(baseConfig.client).toBe(clientConfig.getEndpoint('sx/default'));
+      expect(baseConfig.client.endpoint).toBe('sx/default');
+    });
+
+    it('Should set provided HttpClient instance as a client.', function() {
+      let container  = new Container();
+      let baseConfig = container.get(BaseConfig);
+      baseConfig.endpoint = new HttpClient;
+
+      configure({container: container, globalResources: noop}, {});
+
+      expect(baseConfig.client instanceof Rest).toBe(true);
+      expect(baseConfig.client.client).toBe(baseConfig.endpoint);
+      expect(baseConfig.client.endpoint).toBe('instance');
     });
 
     it('Should set the default HttpClient as client if no endpoint was supplied.', function() {
@@ -145,6 +159,7 @@ describe('aurelia-authentication', function() {
       expect(baseConfig.endpoint).toEqual(null);
       expect(baseConfig.client instanceof Rest).toBe(true);
       expect(baseConfig.client.client).toBe(container.get(HttpClient));
+      expect(baseConfig.client.endpoint).toBe('singleton');
     });
   });
 });


### PR DESCRIPTION
Setting the client in baseConfig.configure gives access to the client when configurating with a function

``` js
.plugin('aurelia-authentication', config =>{
  config.configure(authConfig);

  // config.client is now the properly set client instead of null as before
}
```
