### PR TITLE
fix(authService): storage events do not work properly in IE11

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -84,6 +84,14 @@ export class AuthService {
 
     LogManager.getLogger('authentication').info('Stored token changed event');
 
+    // IE runs the event handler before updating the storage value. Update it now.
+    // An unset storage key in IE is an empty string, where-as chrome is null
+    if (event.newValue) {
+      this.authentication.storage.set(this.config.storageKey, event.newValue);
+    } else {
+      this.authentication.storage.remove(this.config.storageKey);
+    }
+
     let wasAuthenticated = this.authenticated;
     this.authentication.responseAnalyzed = false;
     this.updateAuthenticated();


### PR DESCRIPTION
IE doesn't handle the storage events properly. In chrome it updates local storage THEN you get the event. In IE you get the event THEN it updates local storage. 

This PR updates it to use the event properties, `key` & `newValue` (see [MDN](https://developer.mozilla.org/en-US/docs/Web/Events/storage))

I made the change to set the storage value immediately as per the event properties, which continued to work in chrome, but IE had an additional issue where the empty value returned an empty string instead of null....
