### PR TITLE
Add a configuration option for the refresh token requests

### DIFF
--- a/doc/refresh_token.md
+++ b/doc/refresh_token.md
@@ -25,6 +25,8 @@ autoUpdateToken: true,
 clientId: false,
 // The the property from which to get the refresh token after a successful token refresh
 refreshTokenProp: 'refresh_token',
+// The proprety name used to send the existing token when refreshing `{ "refreshTokenSubmitProp": '...' }`
+refreshTokenSubmitProp = 'refresh_token';
 
 // If the property defined by `refreshTokenProp` is an object:
 // -----------------------------------------------------------

--- a/src/authService.js
+++ b/src/authService.js
@@ -314,11 +314,12 @@ export class AuthService {
     }
 
     if (this.authentication.updateTokenCallstack.length === 0) {
-      const content = {
+      let content = {
         grant_type: 'refresh_token',
-        refresh_token: this.authentication.getRefreshToken(),
         client_id: this.config.clientId ? this.config.clientId : undefined
       };
+
+      content[this.config.refreshTokenSubmitProp] = this.authentication.getRefreshToken();
 
       this.client.post(this.config.joinBase(this.config.refreshTokenUrl
                                             ? this.config.refreshTokenUrl

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -120,6 +120,8 @@ export class BaseConfig {
   clientId = false;
   // The the property from which to get the refresh token after a successful token refresh. Can also be dotted eg "refreshTokenProp.refreshTokenProp"
   refreshTokenProp = 'refresh_token';
+  // The proprety name used to send the existing token when refreshing `{ "refreshTokenSubmitProp": '...' }`
+  refreshTokenSubmitProp = 'refresh_token';
 
   // If the property defined by `refreshTokenProp` is an object:
   // -----------------------------------------------------------


### PR DESCRIPTION
This pull requests adds a `refreshTokenSubmitProp` that can be used to change the name of the prop used to send the token for token refresh.
