### PR TITLE
Fix ie storage

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -80,7 +80,7 @@ export class AuthService {
    * @param {StorageEvent} event StorageEvent
    */
   storageEventHandler = (event: StorageEvent) => {
-    if (event.key !== this.config.storageKey) {
+    if (event.key !== this.config.storageKey || event.newValue === event.oldValue) {
       return;
     }
 

--- a/src/authService.js
+++ b/src/authService.js
@@ -99,9 +99,14 @@ export class AuthService {
     this.authentication.responseAnalyzed = false;
     this.updateAuthenticated();
 
-    if (this.config.storageChangedRedirect && wasAuthenticated !== this.authenticated) {
-      PLATFORM.location.assign(this.config.storageChangedRedirect);
+    if (wasAuthenticated === this.authenticated) {
+      return;
     }
+
+    if (this.config.storageChangedRedirect) {
+      PLATFORM.location.href = this.config.storageChangedRedirect;
+    }
+    PLATFORM.location.reload();
   }
 
   /**


### PR DESCRIPTION
fixes https://github.com/SpoonX/aurelia-authentication/pull/253#issuecomment-252838310

in ie11/edge storage can be raised twice/backfire where the event in the receiving tab can re-raise the event in the sender tab. since the value will already have changed, this loop can be prevented by ignoring events without value changes.
