### PR TITLE
Add npm version build scripts

### DIFF
--- a/build/tasks/prepare-release.js
+++ b/build/tasks/prepare-release.js
@@ -2,13 +2,60 @@ var gulp = require('gulp');
 var runSequence = require('run-sequence');
 var paths = require('../paths');
 var conventionalChangelog = require('gulp-conventional-changelog');
-var fs = require('fs');
 var bump = require('gulp-bump');
 var args = require('../args');
+var through2 = require('through2');
+var fs = require('fs');
+var jsonFormat = require('gulp-json-format');
 
-gulp.task('bump-version', function(){
+var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
+
+gulp.task('bump-version', function() {
   return gulp.src(['./package.json', './bower.json'])
-    .pipe(bump({type:args.bump })) //major|minor|patch|prerelease
+    .pipe(bump({type: args.bump})) //major|minor|patch|prerelease
+    .pipe(gulp.dest('./'));
+});
+
+// set bower version to the pkg.version
+gulp.task('bump-bower', function() {
+  return gulp.src(['./bower.json'])
+    .pipe(bump({version: pkg.version}))
+    .pipe(gulp.dest('./'));
+});
+
+// set in package.json the dependencies to pkg.jspm.dependencies and ensure jspm.jspmPackage = true
+gulp.task('update-package-json', function() {
+  return gulp.src(['./package.json'])
+    .pipe(through2.obj(function(file, enc, callback) {
+      var json = JSON.parse(file.contents.toString('utf8'));
+
+      json.jspm.jspmPackage = true;
+      json.jspm.peerDependencies = pkg.jspm.dependencies;
+      json.dependencies = pkg.jspm.dependencies;
+
+      file.contents = new Buffer(JSON.stringify(json));
+      this.push(file);
+
+      return callback();
+    }))
+    .pipe(jsonFormat(2))
+    .pipe(gulp.dest('./'));
+});
+
+// set in bower.json the dependencies to pkg.jspm.dependencies and ensure jspm.jspmPackage = true
+gulp.task('update-bower-json', function() {
+  return gulp.src(['./bower.json'])
+    .pipe(through2.obj(function(file, enc, callback) {
+      var json = JSON.parse(file.contents.toString('utf8'));
+
+      json.dependencies = pkg.jspm.dependencies;
+
+      file.contents = new Buffer(JSON.stringify(json));
+      this.push(file);
+
+      return callback();
+    }))
+    .pipe(jsonFormat(2))
     .pipe(gulp.dest('./'));
 });
 
@@ -21,12 +68,22 @@ gulp.task('changelog', function () {
   .pipe(gulp.dest(paths.doc));
 });
 
-gulp.task('prepare-release', function(callback){
+gulp.task('prepare-release', function(callback) {
   return runSequence(
     'build',
     'lint',
     'bump-version',
     //'doc',
+    'changelog',
+    callback
+  );
+});
+
+gulp.task('prepare-package', function(callback) {
+  return runSequence(
+    'update-package-json',
+    'update-bower-json',
+    'bump-bower',
     'changelog',
     callback
   );

--- a/build/tasks/prepare-release.js
+++ b/build/tasks/prepare-release.js
@@ -73,6 +73,8 @@ gulp.task('prepare-release', function(callback) {
     'build',
     'lint',
     'bump-version',
+    'update-package-json',
+    'update-bower-json',
     //'doc',
     'changelog',
     callback

--- a/package.json
+++ b/package.json
@@ -25,10 +25,9 @@
   "scripts": {
     "test": "gulp test",
     "build": "gulp build",
-    "gitpublish": "git add -A dist doc/CHANGELOG.md bower.json && git push && git push --tags",
     "preversion": "npm test",
-    "version": "npm run build && gulp prepare-package",
-    "postpublish": "npm run gitpublish"
+    "version": "npm run build && gulp prepare-package && git add -A dist doc/CHANGELOG.md bower.json",
+    "postpublish": "git push && git push --tags"
   },
   "jspm": {
     "registry": "npm",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,12 @@
     "url": "https://github.com/spoonx/aurelia-authentication"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp test"
+    "test": "gulp test",
+    "build": "gulp build",
+    "gitpublish": "git add -A dist doc/CHANGELOG.md bower.json && git push && git push --tags",
+    "preversion": "npm test",
+    "version": "npm run build && gulp prepare-package",
+    "postpublish": "npm run gitpublish"
   },
   "jspm": {
     "registry": "npm",
@@ -84,6 +89,7 @@
     "jwt-decode": "^2.0.0"
   },
   "devDependencies": {
+    "gulp-json-format": "^1.0.0",
     "spoonx-tools": "^0.3.0"
   },
   "aurelia": {


### PR DESCRIPTION
usage eg:
`npm version patch && npm publish`

npm (pre)version: (tags and does a git commit afterwards itself)
- lint
- test
- build
- bump
- ensure package consistency
- git add changes

npm postpublish:
- push to git
- push tag to git
