### PR TITLE
fix(authService): storageChangedReload  optional (default: false)

### DIFF
--- a/doc/Quick start.md
+++ b/doc/Quick start.md
@@ -36,7 +36,8 @@ export default {
     profileUrl: 'me',
     unlinkUrl: 'me/unlink',
     loginOnSignup: false,
-    expiredRedirect: 1, // redirect to logoutRedirect after token expiration
+    storageChangedReload: true,    // ensure secondary tab reloading after auth status changes
+    expiredRedirect: 1,            // redirect to logoutRedirect after token expiration
     providers: {
         google: {
           url: 'google',

--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -123,6 +123,8 @@ platform = 'browser';
 storage = 'localStorage';
 // The key used for storing the authentication response locally
 storageKey = 'aurelia_authentication';
+// full page reload if authorization changed in another tab
+storageChangedReload = false;
 // optional function to extract the expiration date. takes the server response as parameter
 // eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() + serverResponse.expires_in * 1000;
 getExpirationDateFromResponse = null;

--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -123,7 +123,7 @@ platform = 'browser';
 storage = 'localStorage';
 // The key used for storing the authentication response locally
 storageKey = 'aurelia_authentication';
-// full page reload if authorization changed in another tab
+// full page reload if authorization changed in another tab (recommended to set it to 'true')
 storageChangedReload = false;
 // optional function to extract the expiration date. takes the server response as parameter
 // eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() + serverResponse.expires_in * 1000;

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -7,8 +7,9 @@ Set your custom configuration. You can find all options and the default values i
 ```js
 /* authConfig.js */
 export default {
-    endpoint: 'auth',             // use 'auth' endpoint for the auth server
-    configureEndpoints: ['auth']  // add Authorization header to 'auth' endpoint
+    endpoint: 'auth',              // use 'auth' endpoint for the auth server
+    configureEndpoints: ['auth'],  // add Authorization header to 'auth' endpoint
+    storageChangedReload: true,    // ensure secondary tab reloading after auth status changes
     facebook: {
         clientId: 'your client id' // set your third-party providers client ids
     }

--- a/src/authService.js
+++ b/src/authService.js
@@ -106,7 +106,10 @@ export class AuthService {
     if (this.config.storageChangedRedirect) {
       PLATFORM.location.href = this.config.storageChangedRedirect;
     }
-    PLATFORM.location.reload();
+
+    if (this.config.storageChangedReload) {
+      PLATFORM.location.reload();
+    }
   }
 
   /**

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -151,6 +151,8 @@ export class BaseConfig {
   storage = 'localStorage';
   // The key used for storing the authentication response locally
   storageKey = 'aurelia_authentication';
+  // full page reload if authorization changed in another tab
+  storageChangedReload = false;
   // optional function to extract the expiration date. takes the server response as parameter
   // eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() + serverResponse.expires_in * 1000;
   getExpirationDateFromResponse = null;

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -151,7 +151,7 @@ export class BaseConfig {
   storage = 'localStorage';
   // The key used for storing the authentication response locally
   storageKey = 'aurelia_authentication';
-  // full page reload if authorization changed in another tab
+// full page reload if authorization changed in another tab (recommended to set it to 'true')
   storageChangedReload = false;
   // optional function to extract the expiration date. takes the server response as parameter
   // eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() + serverResponse.expires_in * 1000;


### PR DESCRIPTION
ref https://github.com/SpoonX/aurelia-authentication/issues/278

i'm not sure about the default false there. i'd prefer true since that prevents sensitive data still being displayed

@RWOverdijk thoughts?
