### PR TITLE
fix(auth0): Fix auth rejection for non severe errors

### DIFF
--- a/src/authLock.js
+++ b/src/authLock.js
@@ -78,6 +78,10 @@ export class AuthLock {
         });
       });
       this.lock.on('unrecoverable_error', err => {
+        if (!lockOptions.auth.redirect) {
+          // hides the lock popup, as it doesn't do so automatically
+          this.lock.hide();
+        }
         reject(err);
       });
       this.lock.show();

--- a/src/authLock.js
+++ b/src/authLock.js
@@ -77,7 +77,7 @@ export class AuthLock {
           access_token: authResponse.idToken
         });
       });
-      this.lock.on('authorization_error', err => {
+      this.lock.on('unrecoverable_error', err => {
         reject(err);
       });
       this.lock.show();


### PR DESCRIPTION
I attached to the wrong "error" event on the `lock` instance, and I was rejecting the entire auth promise for recoverable errors (like custom rules rejections, etc.).
This fix corrects the above by attaching to the correct handler (`unrecoverable_error`).

Please merge & release ASAP, as it could be a critical issue for auth0 users..
