### PR TITLE
More consistent redirectUrl overwrite 

### DIFF
--- a/doc/api_authService.md
+++ b/doc/api_authService.md
@@ -145,9 +145,9 @@ Retrieves (GET) the profile from the BaseConfig.profileUrl. Accepts criteria. If
 
 #### Parameters
 
-| Parameter | Type                      | Description                           |
-| --------- | ------------------------- | ------------------------------------- |
-| criteria  | {[{} / number ´/ string]} | An ID, or object of supported filters |
+| Parameter | Type                     | Description                           |
+| --------- | ------------------------ | ------------------------------------- |
+| criteria  | {[{} | number | string]} | An ID, or object of supported filters |
 
 #### Returns
 
@@ -173,7 +173,7 @@ Updates the profile to the BaseConfig.profileUrl using BaseConfig.profileMethod 
 | Parameter | Type                     | Description                           |
 | --------- | ------------------------ | ------------------------------------- |
 | body      | {}                       | The body                              |
-| criteria  | [{} / number / string]   | An ID, or object of supported filters |
+| criteria  | [{} | number | string]   | An ID, or object of supported filters |
 
 #### Returns
 
@@ -344,7 +344,7 @@ Signup locally using BaseConfig.signupUrl either with credentials strings or an 
 | email         | string                  | Passed on as email: email                            |
 | password      | string                  | Passed on as password: password                      |
 | [options]     | [{}]                    | Options object passed to aurelia-api                 |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
+| [redirectUri] | [string]                | redirectUri overwrite. '' = no redirection           |
 
 #### Parameters v2
 
@@ -352,7 +352,7 @@ Signup locally using BaseConfig.signupUrl either with credentials strings or an 
 | ------------- | ----------------------- | ---------------------------------------------------- |
 | credentials   | {}                      | Passed on credentials object                         |
 | [options]     | [{}]                    | Options object passed to aurelia-api                 |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
+| [redirectUri] | [string]                | redirectUri overwrite. '' = no redirection           |
 
 #### Returns
 
@@ -393,7 +393,7 @@ Login locally using BaseConfig.loginUrl either with credentials strings or an ob
 | email         | string                  | Passed on as email: email                            |
 | password      | string                  | Passed on as password: password                      |
 | [options]     | [{}]                    | Options object passed to aurelia-api                 |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
+| [redirectUri] | [string]                | redirectUri overwrite. '' = no redirection           |
 
 #### Parameters v2
 
@@ -401,7 +401,7 @@ Login locally using BaseConfig.loginUrl either with credentials strings or an ob
 | ------------- | ----------------------- | ---------------------------------------------------- |
 | credentials   | {}                      | Passed on credentials object                         |
 | [options]     | [{}]                    | Options object passed to aurelia-api                 |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
+| [redirectUri] | [string]                | redirectUri overwrite. '' = no redirection           |
 
 #### Returns
 
@@ -437,15 +437,17 @@ this.authService.login({
 
 ----------
 
-### .logout([redirectUri])
+### .logout([redirectUri [, query [, name]]])
 
 Logout locally by deleting the authentication information from the storage. Redirects to BaseConfig.logoutRedirect if set. The redirectUri parameter overwrites the BaseConfig.logoutRedirect setting. Set to 0 it prevents redirection. Set to a string, will redirect there. If BaseConfig.logoutUrl is set, a logout request is send to the server first using the BaseConfig.logoutMethod.
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                          |
-| ------------- | ----------------------- | ---------------------------------------------------- |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
+| Parameter     | Type      | Description                                 |
+| ------------- | --------- | ------------------------------------------- |
+| [redirectUri] | [string]  | redirectUri overwrite. '' = no redirection  |
+| [query]       | [string]  | optional query string for the uri           |
+| [name]        | [string]  | optional provider logout and state checking |
 
 #### Returns
 
@@ -473,11 +475,11 @@ Authenticate with third-party with the BaseConfig.providers settings. The login 
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                          |
-| ------------- | ----------------------- | ---------------------------------------------------- |
-| provider      | string                  | Provider name of BaseConfig.providers                |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
-| [userData]    | [{}]                    | userData object passed to provider                   |
+| Parameter     | Type      | Description                                |
+| ------------- | --------- | ------------------------------------------ |
+| provider      | string    | Provider name of BaseConfig.providers      |
+| [redirectUri] | [string]  | redirectUri overwrite. '' = no redirection |
+| [userData]    | [{}]      | userData object passed to provider         |
 
 #### Returns
 
@@ -498,10 +500,10 @@ Unlink third-party with the BaseConfig.providers settings. Optionally redirects 
 
 #### Parameters
 
-| Parameter     | Type                    | Description                                          |
-| ------------- | ----------------------- | ---------------------------------------------------- |
-| provider      | string                  | Provider name of BaseConfig.providers                |
-| [redirectUri] | [string/0/null/undef ]  | redirectUri overwrite. 0=off, null/undef=use default |
+| Parameter     | Type      | Description                                |
+| ------------- | --------- | ------------------------------------------ |
+| provider      | string    | Provider name of BaseConfig.providers      |
+| [redirectUri] | [string]  | redirectUri overwrite. '' = no redirection |
 
 #### Returns
 
@@ -517,5 +519,3 @@ this.authService.unlink('facebook', '#/facebook-post-unlink')
 ```
 
 ----------
-
-*Note*: The redirectUri options might seem unusual. This is to provide backwards compatibility.

--- a/src/authService.js
+++ b/src/authService.js
@@ -376,7 +376,7 @@ export class AuthService {
    * @param {[string]|{}} emailOrOptions           [email | options for post request]
    * @param {[string]}    passwordOrRedirectUri    [password | optional redirectUri overwrite]
    * @param {[{}]}        options                  [options]
-   * @param {[string]}    redirectUri              [optional redirectUri overwrite]
+   * @param {[string]}    [redirectUri]            [optional redirectUri overwrite, ''= no redirection]
    *
    * @return {Promise<any>} Server response as Object
    */
@@ -414,7 +414,7 @@ export class AuthService {
    * @param {[string]|{}} emailOrCredentials      email | object with signup data.
    * @param {[string]}    [passwordOrOptions]     [password | options for post request]
    * @param {[{}]}        [optionsOrRedirectUri]  [options | redirectUri overwrite]]
-   * @param {[string]}    [redirectUri]           [optional redirectUri overwrite]
+   * @param {[string]}    [redirectUri]           [optional redirectUri overwrite, ''= no redirection]
    *
    * @return {Promise<Object>|Promise<Error>}    Server response as Object
    */
@@ -449,11 +449,12 @@ export class AuthService {
   }
 
   /**
-   * Logout locally and redirect to redirectUri (if set) or redirectUri of config. Sends logout request first, if set in config
+   * Logout locally and redirect to redirectUri (if set) or redirectUri of config.
+   * Sends logout request first, if set in config
    *
-   * @param {[string]}    [redirectUri]                     [optional redirectUri overwrite]
-   * @param {[string]}    [query]                           [optional query]
-   * @param {[string]}    [name]                            [optional name Name of the provider]
+   * @param {[string]}    [redirectUri]    [optional redirectUri overwrite, ''= no redirection]
+   * @param {[string]}    [query]          [optional query string for the uri]
+   * @param {[string]}    [name]           [optional name Name of the provider]
    *
    * @return {Promise<any>}     Server response as Object
    */

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -291,28 +291,38 @@ export class Authentication {
   /**
    * Redirect (page reload if applicable for the browsers save password option)
    *
-   * @param {[string]} redirectUrl The redirect url
-   * @param {[string]} defaultRedirectUrl The defaultRedirectUrl
+   * @param {string}   redirectUrl The redirect url. To not redirect use an empty string.
+   * @param {[string]} defaultRedirectUrl The defaultRedirectUrl. Used when redirectUrl is undefined
    * @param {[string]} query The optional query string to add the the url
    * @returns {undefined} undefined
    *
    * @memberOf Authentication
    */
-  redirect(redirectUrl?: string, defaultRedirectUrl?: string, query?: string) {
+  redirect(redirectUrl: string, defaultRedirectUrl?: string, query?: string) {
     // stupid rule to keep it BC
     if (redirectUrl === true) {
-      logger.warn('DEPRECATED: Setting redirectUrl === true to actually *not redirect* is deprecated. Set redirectUrl === 0 instead.');
+      logger.warn('DEPRECATED: Setting redirectUrl === true to actually *not redirect* is deprecated. Set redirectUrl === \'\' instead.');
 
       return;
     }
+
     // stupid rule to keep it BC
     if (redirectUrl === false) {
       logger.warn('BREAKING CHANGE: Setting redirectUrl === false to actually *do redirect* is deprecated. Set redirectUrl to undefined or null to use the defaultRedirectUrl if so desired.');
     }
-    // BC hack. explicit 0 means don't redirect. false will be added later and 0 deprecated
+
+    // BC hack. explicit 0 means don't redirect. deprecated in favor of an empty string
     if (redirectUrl === 0) {
+      logger.warn('BREAKING CHANGE: Setting redirectUrl === 0 is deprecated. Set redirectUrl to \'\' instead.');
+
       return;
     }
+
+    // Empty string means don't redirect overwrite.
+    if (redirectUrl === '') {
+      return;
+    }
+
     if (typeof redirectUrl === 'string') {
       PLATFORM.location.href = encodeURI(redirectUrl + (query ? `?${buildQueryString(query)}` : ''));
     } else if (defaultRedirectUrl) {


### PR DESCRIPTION
Options to not redirect changed from 0 to '' for consistency and ease of use

@nexbit if i deprecate 0 in favor of '' and keep the dts, is that a breaking change? for js users it isn't, but for ts? but then, they had to use string anyways, so i guess it's not breaking? but could a previous used '' (which now doesn't redirect) be breaking. i guess so, question is, whether anyone had used it like that

closes https://github.com/SpoonX/aurelia-authentication/issues/294

pending https://github.com/SpoonX/spoonx-tools/pull/10
