### PR TITLE
Math in getExpirationDateFromResponse example was wrong

### DIFF
--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -126,7 +126,7 @@ storageKey = 'aurelia_authentication';
 // full page reload if authorization changed in another tab (recommended to set it to 'true')
 storageChangedReload = false;
 // optional function to extract the expiration date. Takes the server response as parameter and returns number of seconds! since 1 January 1970 00:00:00 UTC (Unix Epoch) 
-// eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() + serverResponse.expires_in * 1000;
+// eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() + serverResponse.expires_in / 1000;
 getExpirationDateFromResponse = null;
 // optional function to extract the access token from the response. Takes the server response as parameter and returns a token
 // eg: getAccessTokenFromResponse = serverResponse => serverResponse.data[0].access_token;


### PR DESCRIPTION
We need to divide, not multiply, by 1000 to get the seconds from milliseconds.