### PR TITLE
(bug) allow object passed as second arg to authService.login()

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -437,7 +437,7 @@ export class AuthService {
    *
    * @return {Promise<Object>|Promise<Error>}    Server response as Object
    */
-  login(emailOrCredentials: string|{}, passwordOrOptions?: string, optionsOrRedirectUri?: {}, redirectUri?: string): Promise<any> {
+  login(emailOrCredentials: string|{}, passwordOrOptions?: string|{}, optionsOrRedirectUri?: {}, redirectUri?: string): Promise<any> {
     let normalized = {};
 
     if (typeof emailOrCredentials === 'object') {


### PR DESCRIPTION
modified the type of the second argument to allow string or object as the first argument to the login function does