### PR TITLE
doc: Typos corrected in documentation

### DIFF
--- a/doc/Quick start.md
+++ b/doc/Quick start.md
@@ -30,7 +30,7 @@ Here is a sample of a close to minimal custom setting:
 ```js
 export default {
     endpoint: 'auth',
-    configureEndpoints: ['auth', 'protected-api']
+    configureEndpoints: ['auth', 'protected-api'],
     loginUrl: 'login',  
     signupUrl: 'users',
     profileUrl: 'me',

--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -39,7 +39,7 @@ baseUrl = '';
 loginUrl = '/auth/login';
 // The API endpoint to which logout requests are sent (not needed for jwt)
 logoutUrl = null;
-// The HTTP method used for 'unlink' requests (Options: 'get' or 'post')
+// The HTTP method used for 'logout' requests (Options: 'get' or 'post')
 logoutMethod = 'get';
 // The API endpoint to which signup requests are sent
 signupUrl = '/auth/signup';


### PR DESCRIPTION
Added a missing comma to the Quick Start sample config.
Corrected a comment in the config stating the wrong method.