### PR TITLE
Correct way to access token

### DIFF
--- a/src/authentication.js
+++ b/src/authentication.js
@@ -143,7 +143,7 @@ export class Authentication {
   }
 
   isAuthenticated(): boolean {
-    return !!this.accessToken && !this.isTokenExpired();
+    return !!this.getAccessToken() && !this.isTokenExpired();
   }
 
   /* get and set from response */


### PR DESCRIPTION
Directly using a field was not working with the sessionStorage on the
first load.