### PR TITLE
feat(authService): add default headers and clientSecret in config

### DIFF
--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -82,6 +82,8 @@ useRefreshToken = false;
 autoUpdateToken = true;
 // Oauth Client Id
 clientId = false;
+// Oauth Client secret
+clientSecret = null;
 // The property from which to get the refresh token after a successful token refresh
 refreshTokenProp = 'refresh_token';
 
@@ -138,6 +140,10 @@ getRefreshTokenFromResponse = null;
 // List of value-converters to make global
 globalValueConverters = ['authFilterValueConverter'];
 
+ // Default headers for login and token-update endpoint
+defaultHeadersForTokenRequests = {
+  'Content-Type': 'application/json'
+}
 
 //OAuth provider specific related configuration
 // ============================================

--- a/src/authService.js
+++ b/src/authService.js
@@ -366,15 +366,21 @@ export class AuthService {
 
     if (this.authentication.updateTokenCallstack.length === 0) {
       let content = {
-        grant_type: 'refresh_token',
-        client_id : this.config.clientId ? this.config.clientId : undefined
+        grant_type: 'refresh_token'
       };
+
+      if(this.config.clientId) {
+        content.client_id = this.config.clientId;
+      }
+      if(this.config.clientSecret) {
+        content.client_secret = this.config.clientSecret;
+      }
 
       content[this.config.refreshTokenSubmitProp] = this.authentication.getRefreshToken();
 
       this.client.post(this.config.joinBase(this.config.refreshTokenUrl
                                             ? this.config.refreshTokenUrl
-                                            : this.config.loginUrl), content)
+                                            : this.config.loginUrl), content, this.config.getOptionsForTokenRequests())
         .then(response => {
           this.setResponseObject(response);
           this.authentication.resolveUpdateTokenCallstack(this.isAuthenticated());
@@ -442,19 +448,23 @@ export class AuthService {
 
     if (typeof emailOrCredentials === 'object') {
       normalized.credentials = emailOrCredentials;
-      normalized.options     = passwordOrOptions;
+      normalized.options     = this.config.getOptionsForTokenRequests(passwordOrOptions);
       normalized.redirectUri = optionsOrRedirectUri;
     } else {
       normalized.credentials = {
         'email'   : emailOrCredentials,
         'password': passwordOrOptions
       };
-      normalized.options     = optionsOrRedirectUri;
+      normalized.options     = this.config.getOptionsForTokenRequests(optionsOrRedirectUri);
       normalized.redirectUri = redirectUri;
     }
 
     if (this.config.clientId) {
       normalized.credentials.client_id = this.config.clientId;
+    }
+
+    if(this.config.clientSecret) {
+      normalized.credentials.client_secret = this.config.clientSecret;
     }
 
     return this.client.post(this.config.joinBase(this.config.loginUrl), normalized.credentials, normalized.options)

--- a/src/authService.js
+++ b/src/authService.js
@@ -369,10 +369,10 @@ export class AuthService {
         grant_type: 'refresh_token'
       };
 
-      if(this.config.clientId) {
+      if (this.config.clientId) {
         content.client_id = this.config.clientId;
       }
-      if(this.config.clientSecret) {
+      if (this.config.clientSecret) {
         content.client_secret = this.config.clientSecret;
       }
 
@@ -463,7 +463,7 @@ export class AuthService {
       normalized.credentials.client_id = this.config.clientId;
     }
 
-    if(this.config.clientSecret) {
+    if (this.config.clientSecret) {
       normalized.credentials.client_secret = this.config.clientSecret;
     }
 

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -34,6 +34,10 @@ export class BaseConfig {
     }
   }
 
+  getOptionsForTokenRequests(options?:{} = {}): {} {
+      return extend(true, {}, {headers: this.defaultHeadersForTokenRequests}, options);
+  }
+
   /* ----------- default  config ----------- */
 
   // Used internally. The used Rest instance; set during configuration (see index.js)
@@ -117,6 +121,8 @@ export class BaseConfig {
   autoUpdateToken = true;
   // Oauth Client Id
   clientId = false;
+  // Oauth Client secret
+  clientSecret = null;
   // The the property from which to get the refresh token after a successful token refresh. Can also be dotted eg "refreshTokenProp.refreshTokenProp"
   refreshTokenProp = 'refresh_token';
   // The property name used to send the existing token when refreshing `{ "refreshTokenSubmitProp": '...' }`
@@ -165,6 +171,11 @@ export class BaseConfig {
 
   // List of value-converters to make global
   globalValueConverters = ['authFilterValueConverter'];
+
+  // Default headers for login and token-update endpoint
+  defaultHeadersForTokenRequests = {
+    'Content-Type': 'application/json'
+  }
 
   //OAuth provider specific related configuration
   // ============================================

--- a/test/baseConfig.spec.js
+++ b/test/baseConfig.spec.js
@@ -27,4 +27,27 @@ describe('BaseConfig', () => {
       expect(baseConfig.joinBase('/xy')).toBe('http://localhost:1927/xy');
     });
   });
+
+  describe('.getOptionsForTokenRequests()', () => {
+    it('When given empty or undefined object as input, should return default values set in config object', () => {
+      const container = new Container();
+      const baseConfig = container.get(BaseConfig);
+      const resultOptions = baseConfig.getOptionsForTokenRequests();
+
+      expect(resultOptions.headers['Content-Type']).toBe(baseConfig.defaultHeadersForTokenRequests['Content-Type']);
+    });
+
+    it('When given object with values, should return object with values overridden by input object', () => {
+      const container = new Container();
+      const baseConfig = container.get(BaseConfig);
+      const contentType = 'test';
+      const resultOptions = baseConfig.getOptionsForTokenRequests({
+        headers: {
+          'Content-Type': contentType
+        }
+      });
+
+      expect(resultOptions.headers['Content-Type']).toBe(resultOptions.headers['Content-Type']);
+    });
+  });
 });


### PR DESCRIPTION
Add some default headers to the baseConfig that will be appended when using .login() and .refreshToken(). This is to support IdentityServer 4 with the openId spec http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest.
Gives us the posibility to use application/x-www-form-urlencoded as content-type.