### PR TITLE
feat(authService): support empty login request

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -437,14 +437,14 @@ export class AuthService {
    *
    * @return {Promise<Object>|Promise<Error>}    Server response as Object
    */
-  login(emailOrCredentials: string|{}, passwordOrOptions?: string|{}, optionsOrRedirectUri?: {}, redirectUri?: string): Promise<any> {
+  login(emailOrCredentials?: string|{}, passwordOrOptions?: string|{}, optionsOrRedirectUri?: {}, redirectUri?: string): Promise<any> {
     let normalized = {};
 
     if (typeof emailOrCredentials === 'object') {
       normalized.credentials = emailOrCredentials;
       normalized.options     = passwordOrOptions;
       normalized.redirectUri = optionsOrRedirectUri;
-    } else {
+    } else if (typeof emailOrCredentials === 'string') {
       normalized.credentials = {
         'email'   : emailOrCredentials,
         'password': passwordOrOptions


### PR DESCRIPTION
In order to authenticate with Windows authentication no request body is required.  For this to work we needed to override the defaults of the api endpoint so there was no accept and content-type header to stop Chrome sending a pre-flight request. This is because Chrome does not attach credentials to pre-flight requests and yet IIS rejects anything that doesn't have them.

That was all fine until we tried to use IE with the fetch polyfill. 

Since content-type is not application/json aurelia-api does not stringify the empty object we were passing to login and then fetch rejects it as an unsupported body.

Including the content-type header works in IE, the empty object is stringified and sends credentials on the pre-flight so everything is fine, except now Chrome doesn't work.

This seemed to be the simplest solution.