### PR TITLE
fix(authService): storageEventHandler change

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -86,14 +86,12 @@ export class AuthService {
     }
 
     // in case auto refresh tokens are enabled
-    if(this.config.autoUpdateToken
-      && this.authentication.getAccessToken()
-      && this.authentication.getRefreshToken())
-      {
-        // we just need to check the status of the updated token we have in storage
-        this.authentication.updateAuthenticated();
-        return;
-      }
+    if (this.config.autoUpdateToken && this.authentication.getAccessToken() && this.authentication.getRefreshToken()) {
+      // we just need to check the status of the updated token we have in storage
+      this.authentication.updateAuthenticated();
+
+      return;
+    }
 
     logger.info('Stored token changed event');
 

--- a/src/authService.js
+++ b/src/authService.js
@@ -85,6 +85,16 @@ export class AuthService {
       return;
     }
 
+    // in case auto refresh tokens are enabled
+    if(this.config.autoUpdateToken
+      && this.authentication.getAccessToken()
+      && this.authentication.getRefreshToken())
+      {
+        // we just need to check the status of the updated token we have in storage
+        this.authentication.updateAuthenticated();
+        return;
+      }
+
     logger.info('Stored token changed event');
 
     // IE runs the event handler before updating the storage value. Update it now.


### PR DESCRIPTION
In case refresh token is used, when storageEventHandler is raised - we just validate the token.

Fix for #327