### PR TITLE
feat(fetchClientConfig): logout when token is invalidated by server

### DIFF
--- a/doc/baseConfig.md
+++ b/doc/baseConfig.md
@@ -60,6 +60,8 @@ unlinkMethod = 'get';
 authHeader = 'Authorization';
 // The token name used in the header of API requests that require authentication
 authTokenType = 'Bearer';
+// Logout when the token is invalidated by the server
+logoutOnInvalidtoken = false;
 // The property from which to get the access token after a successful login or signup
 accessTokenProp = 'access_token';
 
@@ -127,7 +129,7 @@ storage = 'localStorage';
 storageKey = 'aurelia_authentication';
 // full page reload if authorization changed in another tab (recommended to set it to 'true')
 storageChangedReload = false;
-// optional function to extract the expiration date. Takes the server response as parameter and returns NumericDate = number of seconds! since 1 January 1970 00:00:00 UTC (Unix Epoch) 
+// optional function to extract the expiration date. Takes the server response as parameter and returns NumericDate = number of seconds! since 1 January 1970 00:00:00 UTC (Unix Epoch)
 // eg (expires_in in sec): getExpirationDateFromResponse = serverResponse => new Date().getTime() / 1000 + serverResponse.expires_in;
 getExpirationDateFromResponse = null;
 // optional function to extract the access token from the response. Takes the server response as parameter and returns a token

--- a/src/baseConfig.js
+++ b/src/baseConfig.js
@@ -101,6 +101,8 @@ export class BaseConfig {
   authHeader = 'Authorization';
   // The token name used in the header of API requests that require authentication
   authTokenType = 'Bearer';
+  // Logout when the token is invalidated by the server
+  logoutOnInvalidtoken = false;
   // The the property from which to get the access token after a successful login or signup. Can also be dotted eg "accessTokenProp.accessTokenName"
   accessTokenProp = 'access_token';
 

--- a/src/fetchClientConfig.js
+++ b/src/fetchClientConfig.js
@@ -52,6 +52,10 @@ export class FetchConfig {
           if (response.status !== 401) {
             return resolve(response);
           }
+          // logout when server invalidated the authorization token but the token itself is still valid
+          if (this.config.httpInterceptor && this.config.logoutOnInvalidtoken && !this.authService.isTokenExpired()) {
+            return reject(this.authService.logout());
+          }
           // resolve unexpected authorization errors (not a managed request or token not expired)
           if (!this.config.httpInterceptor || !this.authService.isTokenExpired()) {
             return resolve(response);


### PR DESCRIPTION
A token can be invalidated by the server. The token itself is still "valid", in this case force the user to re-login.