### PR TITLE
fix: Change so we do not try to logout upon 401 response when logoutOnInvalidtoken is set and the user is not authenticated

### DIFF
--- a/src/fetchClientConfig.js
+++ b/src/fetchClientConfig.js
@@ -52,6 +52,12 @@ export class FetchConfig {
           if (response.status !== 401) {
             return resolve(response);
           }
+
+          // when we get a 401 and are not logged in, there's not much to do except reject the request
+          if (!this.authService.authenticated) {
+            return reject(response);
+          }
+
           // logout when server invalidated the authorization token but the token itself is still valid
           if (this.config.httpInterceptor && this.config.logoutOnInvalidtoken && !this.authService.isTokenExpired()) {
             return reject(this.authService.logout());


### PR DESCRIPTION
Here's a simple PR for #354. Tests are passing but I couldn't understand how to write a new test for the error condition.

There should probably be a new test in `fetchClientConfig.spec.js`, similar to `Should not intercept requests when unauthenticated.` but where *logoutOnInvalidtoken*  in the config is set to `true` and a 401 response is received, but it wasn't obvious to me how to write that.
