### PR TITLE
fix(authService): call callback with false when authentication goes wrong

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -309,7 +309,10 @@ export class AuthService {
             callback(this.authenticated); // eslint-disable-line callback-return
           }
         })
-        .catch(error => logger.warn(error.message));
+        .catch(error => {
+          logger.warn(error.message);
+          callback(false); // eslint-disable-line callback-return
+        });
 
       authenticated = true;
     } else if (typeof callback === 'function') {
@@ -319,6 +322,7 @@ export class AuthService {
           callback(authenticated); // eslint-disable-line callback-return
         } catch(error) {
           logger.warn(error.message);
+          callback(false); // eslint-disable-line callback-return
         }
       }, 1);
     }


### PR DESCRIPTION
Using `isAuthenticated` with a callback and the refreshing fails it never calls the callback.