### PR TITLE
Reject a promise when token could not be updated

### DIFF
--- a/src/fetchClientConfig.js
+++ b/src/fetchClientConfig.js
@@ -80,7 +80,9 @@ export class FetchConfig {
             request.headers.set(this.config.authHeader, token);
 
             return this.httpClient.fetch(request).then(resolve);
-          });
+          })
+          // reject if could not update the token
+          .catch(e => reject(e));
         });
       }
     };


### PR DESCRIPTION
Let's say I've got current and refresh tokens in the storage. Current token is already expired and refresh one is not. But refresh one has been invalidated on a server.

In this scenario an original request will fail with 401 and http interceptor will try to update the token. 
This update request will also fail because the refresh token has been invalidated. As a result, this uncaught rejection will break the execution flow completely.

There is no way to catch this rejection in the code which made the original call to an authorised endpoint.