### PR TITLE
fix(auth0): fix access and id token assignments

### DIFF
--- a/doc/auth0.md
+++ b/doc/auth0.md
@@ -2,9 +2,27 @@
 
 The Auth0 provider is different than the other providers you normally use with `aurelia-authentication`. It should be the only provider configured in your app, and you need to set at least the `clientId` and `clientDomain` config properties. The `oauthType` property must be set equal to *auth0-lock*.
 
-At the time of writing this, it relies by default on the [Auth0 Lock](https://auth0.com/lock) library, that handles both the UI and the logic for all the authentication tasks. You can load it by including a script tag directly in your index.html file, or alternatively with a loader of your choice.
+At the time of writing this, it relies by default on the [Auth0 Lock](https://auth0.com/lock) library, that handles both the UI and the logic for all the authentication tasks. You can load it by including a script tag directly in your index.html file, or alternatively with a loader of your choice.  It is highly encouraged to use Lock version 11 or greater as in mid 2018, Auth0 is beginning to decpreciate acccess to and ability to integrate with older API endpoints and versions of Lock.
 
-You cannot use the `open` method with this provider, but you'll always call `authenticate` instead (see the code snippet at the end of this article). The `authenticate` method will return an object with an `access_token` property, but despite its name that property will contain an **ID Token** (in the form of a *JWT*) containing at least the user's `sub` id. The login flow is described better in this [article](https://auth0.com/docs/protocols#oauth-for-native-clients-and-javascript-in-the-browser).
+You cannot use the `open` method with this provider, but you'll always call `authenticate` instead (see the code snippet at the end of this article). The `authenticate` method will return an object with an `access_token` and `id_token` properties.  The login flow is described better in this [article](https://auth0.com/docs/protocols#oauth-for-native-clients-and-javascript-in-the-browser).
+
+Previous versions of the Auth0 integration only returned an `access_token`, but despite its name the property contained an **ID Token** (in the form of a *JWT*) containing at least the user's `sub` id. To better conform with Auth0 standards, this has changed and you will now recieve both the `access_token` and `id_token`.  With the new `getIdTokenPayload()` function you can then easily grab the payload of the `id_token` and use it within your application.
+
+With the change to the returned object, if you want to use the `access_token`, you must set the configuration option `getAccessTokenFromResponse` to `true`.  The `access_token` returned from Auth0 will be opaque and not in a standard JWT format. However it can still be used to authenticate to certain Auth0 API endpoints such as [/userinfo](https://auth0.com/docs/api/authentication#user-profile).  
+
+If you want an `access_token` in JWT format that is not opaque and be also be used to store/retreive information in it, then in the Auth0 portion of the config you must pass along an `audience`.  It would look something like this (other options omitted for brevity):
+```
+{
+  auth0: {
+    lockOptions: {
+      auth: {
+        audience: 'https://YOUR_AUTH0_URL/api/v2/'
+      }
+    }
+  }
+}
+```
+
 
 Other *Lock* properties should be set under the `lockOptions` config property, except for:
 
@@ -40,7 +58,7 @@ import {Cookie} from 'aurelia-cookie';
 ```
 
 ## Setting auth0 lock params
-In case you need to get more than just an accesstoken, you must modify the lockOptions as shown below. Parameters are described here: [Lock Authentication params](https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters)
+If you need to configure additional parameters to pass to Auth0, then you can pass those in the `lockOptions` object as seen below. Parameters are described here: [Lock Authentication params](https://auth0.com/docs/libraries/lock/v11/configuration)
 
 ```
 const config = {

--- a/src/authLock.js
+++ b/src/authLock.js
@@ -74,7 +74,8 @@ export class AuthLock {
           this.lock.hide();
         }
         resolve({
-          access_token: authResponse.idToken
+          access_token: authResponse.accessToken,
+          id_token    : authResponse.idToken
         });
       });
       this.lock.on('unrecoverable_error', err => {


### PR DESCRIPTION
Current Auth0 plugin assigns the Auth0 id_token to the access_token
object. This fixes that and now you get the Auth0 access_token &
id_token correctly assigned.

This is a breaking change, see [issue #397](https://github.com/SpoonX/aurelia-authentication/issues/397)