### PR TITLE
fix(auth0): extend responseType check

### DIFF
--- a/src/authLock.js
+++ b/src/authLock.js
@@ -93,6 +93,7 @@ export class AuthLock {
         if (provider.responseType === 'token'
           || provider.responseType === 'id_token%20token'
           || provider.responseType === 'token%20id_token'
+          || provider.responseType === 'token id_token'
         ) {
           return lockResponse;
         }


### PR DESCRIPTION
It was necessary to extend the if-check with an additional variant of responseType === 'token id_token' to make it work with auth0-lock v11

Fixes #403