### PR TITLE
fix(authService): update internal authentication fields

### DIFF
--- a/src/authService.js
+++ b/src/authService.js
@@ -85,18 +85,6 @@ export class AuthService {
       return;
     }
 
-    // in case auto refresh tokens are enabled, tokens are allowed to differ
-    // logouts (event.newValue===null) and logins (authentication.getAccessToken()===null), need to be handled bellow though
-    if (event.newValue && this.config.autoUpdateToken && this.authentication.getAccessToken() && this.authentication.getRefreshToken()) {
-      // we need to set the whole response object again so that this.authentication.exp gets updated too
-      // this is critical for a scenario when two browser windows are open and one of them refreshes a token
-      this.setResponseObject(this.authentication.getResponseObject());
-
-      return;
-    }
-
-    logger.info('Stored token changed event');
-
     // IE runs the event handler before updating the storage value. Update it now.
     // An unset storage key in IE is an empty string, where-as chrome is null
     if (event.newValue) {
@@ -104,6 +92,17 @@ export class AuthService {
     } else {
       this.authentication.storage.remove(this.config.storageKey);
     }
+    
+    // in case auto refresh tokens are enabled, tokens are allowed to differ
+    // logouts (event.newValue===null) and logins (authentication.getAccessToken()===null), need to be handled bellow though
+    if (event.newValue && this.config.autoUpdateToken && this.authentication.getAccessToken() && this.authentication.getRefreshToken()) {
+      // we need to set the whole response object again so that this.authentication.exp gets updated too
+      // this is critical for a scenario when two browser windows are open and one of them refreshes a token
+      this.setResponseObject(this.authentication.getResponseObject());
+      return;
+    }
+
+    logger.info('Stored token changed event');
 
     let wasAuthenticated = this.authenticated;
 

--- a/src/authService.js
+++ b/src/authService.js
@@ -88,8 +88,9 @@ export class AuthService {
     // in case auto refresh tokens are enabled, tokens are allowed to differ
     // logouts (event.newValue===null) and logins (authentication.getAccessToken()===null), need to be handled bellow though
     if (event.newValue && this.config.autoUpdateToken && this.authentication.getAccessToken() && this.authentication.getRefreshToken()) {
-      // we just need to check the status of the updated token we have in storage
-      this.updateAuthenticated();
+      // we need to set the whole response object again so that this.authentication.exp gets updated too
+      // this is critical for a scenario when two browser windows are open and one of them refreshes a token
+      this.setResponseObject(this.authentication.getResponseObject());
 
       return;
     }

--- a/src/authService.js
+++ b/src/authService.js
@@ -92,13 +92,14 @@ export class AuthService {
     } else {
       this.authentication.storage.remove(this.config.storageKey);
     }
-    
+
     // in case auto refresh tokens are enabled, tokens are allowed to differ
     // logouts (event.newValue===null) and logins (authentication.getAccessToken()===null), need to be handled bellow though
     if (event.newValue && this.config.autoUpdateToken && this.authentication.getAccessToken() && this.authentication.getRefreshToken()) {
       // we need to set the whole response object again so that this.authentication.exp gets updated too
       // this is critical for a scenario when two browser windows are open and one of them refreshes a token
       this.setResponseObject(this.authentication.getResponseObject());
+
       return;
     }
 

--- a/test/authService.spec.js
+++ b/test/authService.spec.js
@@ -997,4 +997,61 @@ describe('AuthService', () => {
         });
     });
   });
+
+  describe('.getExp()', () => {
+    const container   = getContainer();
+    const authService = container.get(AuthService);
+
+    it('Should return exp of the new token set directly in storage.', done => {
+      authService.config.autoUpdateToken = true;
+      authService.config.useRefreshToken = true;
+      authService.setResponseObject({access_token: tokenFuture.jwt, refresh_token: tokenFuture.jwt});
+      const newToken = {
+        payload: {
+          name : 'newToken',
+          admin: true,
+          exp  : '2460017155'
+        },
+        jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidG9rZW5GdXR1cmUiLCJhZG1pbiI6dHJ1ZSwiZXhwIjoiMjQ2MDAxNzE1NSJ9.0BOonoj0DWMRMFFrmv4nrqtcsSE1olFEX7C1_Tnl8a8'
+      };
+
+      const oldValue = window.localStorage.getItem('aurelia_authentication');
+      const newValue = JSON.stringify({access_token: newToken.jwt, refresh_token: newToken.jwt});
+
+      window.localStorage.setItem('aurelia_authentication', newValue);
+      // no events, call manually
+      authService.storageEventHandler(new StorageEvent('storage', {key: 'aurelia_authentication', newValue, oldValue }));
+
+      const exp = authService.getExp();
+      expect(exp).toBe(parseInt(newToken.payload.exp));
+      done();
+    });
+
+    it('Should return exp of the new token set directly in IE storage.', done => {
+      authService.config.autoUpdateToken = true;
+      authService.config.useRefreshToken = true;
+      authService.setResponseObject({access_token: tokenFuture.jwt, refresh_token: tokenFuture.jwt});
+      const newToken = {
+        payload: {
+          name : 'newToken',
+          admin: true,
+          exp  : '2460017155'
+        },
+        jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidG9rZW5GdXR1cmUiLCJhZG1pbiI6dHJ1ZSwiZXhwIjoiMjQ2MDAxNzE1NSJ9.0BOonoj0DWMRMFFrmv4nrqtcsSE1olFEX7C1_Tnl8a8'
+      };
+
+      const oldValue = window.localStorage.getItem('aurelia_authentication');
+      const newValue = JSON.stringify({access_token: newToken.jwt, refresh_token: newToken.jwt});
+
+      // in IE event is dispatched before a key is set
+      // no events, call manually
+      authService.storageEventHandler(new StorageEvent('storage', {key: 'aurelia_authentication', newValue, oldValue }));
+      const exp = authService.getExp();
+      window.localStorage.setItem('aurelia_authentication', newValue);
+
+      expect(exp).toBe(parseInt(newToken.payload.exp));
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
This is critical for a scenario when two or more browser windows are open and one of them refreshes a token.
Previously `this.authentication.exp` was equal to the old token exp, which caused premature sign out event, 
which in its' turn signed out all the open windows.